### PR TITLE
Add trust all certificates option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out the [configuration part](https://thundra.readme.io/docs/nodejs-configu
 | thundra_lambda_trace_response_skip       |  bool  |     false     |
 | thundra_lambda_timeout_margin            | number |     200       |
 | thundra_lambda_http_responseCheck_skip   |  bool  |     false     |
+| thundra_lambda_publish_rest_trustAllCertificates | bool | false   |
 | thundra_lambda_publish_rest_baseUrl      | string |  https<nolink>://collector.thundra.io/api  |
 
 #### 2. Module initialization parameters

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,11 @@ module.exports = (options: any) => {
         const metricPlugin = MetricPlugin(config.metricConfig);
         config.plugins.push(metricPlugin);
     }
+
+    if (config.trustAllCert) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    }
+
     const applicationId = process.env.AWS_LAMBDA_LOG_STREAM_NAME ?
                           process.env.AWS_LAMBDA_LOG_STREAM_NAME.split(']').pop() :
                           Utils.generateId();

--- a/src/plugins/config/ThundraConfig.ts
+++ b/src/plugins/config/ThundraConfig.ts
@@ -4,6 +4,7 @@ import InvocationConfig from './InvocationConfig';
 const koalas = require('koalas');
 
 class ThundraConfig {
+    trustAllCert: boolean;
     apiKey: string;
     disableThundra: boolean;
     traceConfig: TraceConfig;
@@ -21,6 +22,7 @@ class ThundraConfig {
         this.traceConfig = new TraceConfig(options.traceConfig);
         this.metricConfig = new MetricConfig(options.metricConfig);
         this.invocationConfig = new InvocationConfig(options.invocationConfig);
+        this.trustAllCert = koalas(process.env.thundra_lambda_publish_rest_trustAllCertificates, options.trustAllCert, false);
     }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,6 +18,8 @@ delete process.env.thundra_trace_disable;
 delete process.env.thundra_metric_disable;
 delete process.env.thundra_disable;
 delete process.env.thundra_apiKey;
+delete process.env.thundra_lambda_publish_rest_trustAllCertificates;
+delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
 
 describe('Thundra library', () => {
 
@@ -165,4 +167,41 @@ describe('Thundra library', () => {
 
     });
 
+    describe('Authorize All Certs', () => {   
+        describe('enabled by config', () => {   
+            delete process.env.thundra_lambda_publish_rest_trustAllCertificates;
+            delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
+            const originalEvent = {key: 'value'};
+            const originalContext = {};
+            const originalCallback = jest.fn();
+            const originalFunction = jest.fn(() => originalCallback());
+            const ThundraWrapper = new Thundra({apiKey: 'apiKey', trustAllCert: true});
+            const wrappedFunction = new ThundraWrapper(originalFunction);
+            wrappedFunction(originalEvent, originalContext, originalCallback);
+            
+            it('should set environment variable', () => {
+                expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+            });
+        });
+
+        describe('enabled by environment variable', () => {   
+            delete process.env.thundra_lambda_publish_rest_trustAllCertificates;
+            delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
+            process.env.thundra_lambda_publish_rest_trustAllCertificates = true;
+            
+            const originalEvent = {key: 'value'};
+            const originalContext = {};
+            const originalCallback = jest.fn();
+            const originalFunction = jest.fn(() => originalCallback());
+            const ThundraWrapper = new Thundra({apiKey: 'apiKey', trustAllCert: true});
+            const wrappedFunction = new ThundraWrapper(originalFunction);
+            wrappedFunction(originalEvent, originalContext, originalCallback);
+            
+            it('should set environment variable', () => {
+                expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+            });
+        });
+    });
 });


### PR DESCRIPTION
Trusting all https certs can be enabled with `thundra_lambda_publish_rest_trustAllCertificates` environment variable.