### PR TITLE
Thundra Log Plugin NodeJS console integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Check out the [configuration part](https://thundra.readme.io/docs/nodejs-configu
 | thundra_agent_lambda_trace_instrument_integrations_disable      | array  |    []         |
 | thundra_agent_lambda_metric_sample_sampler_timeAware_timeFreq   | number |    300000     |
 | thundra_agent_lambda_metric_sample_sampler_countAware_countFreq | number |    10         |
+| thundra_agent_lambda_log_console_shim_disable                   | bool   |    false      |
 
 #### 2. Module initialization parameters
 

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -27,7 +27,8 @@ export const envVariableKeys = {
     THUNDRA_LAMBDA_TRACE_INSTRUMENT_CONFIG: 'thundra_agent_lambda_trace_instrument_traceableConfig',
     THUNDRA_LAMBDA_TRACE_INSTRUMENT_FILE_PREFIX: 'thundra_agent_lambda_trace_instrument_file_prefix',
     THUNDRA_LAMBDA_TRACE_INTEGRATIONS_DISABLE: 'thundra_agent_lambda_trace_instrument_integrations_disable',
-    THUNDRRA_LAMBDA_LOG_LOGLEVEL: 'thundra_agent_lambda_log_loglevel',
+    THUNDRA_LAMBDA_LOG_CONSOLE_SHIM_DISABLE: 'thundra_agent_lambda_log_console_shim_disable',
+    THUNDRA_LAMBDA_LOG_LOGLEVEL: 'thundra_agent_lambda_log_loglevel',
     THUNDRA_AGENT_LAMBDA_AGENT_DEBUG_ENABLE: 'thundra_agent_lambda_debug_enable',
 
     AWS_LAMBDA_APPLICATION_ID: 'AWS_LAMBDA_APPLICATION_ID',
@@ -460,3 +461,7 @@ export const SQLQueryOperationTypes: any = {
     UPDATE: 'WRITE',
     DELETE: 'WRITE',
 };
+
+export const ConsoleShimmedMethods = ['log', 'debug', 'info', 'warn', 'error'];
+
+export const ConsoleLogContext = 'Console';

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -464,4 +464,6 @@ export const SQLQueryOperationTypes: any = {
 
 export const ConsoleShimmedMethods = ['log', 'debug', 'info', 'warn', 'error'];
 
-export const ConsoleLogContext = 'Console';
+export const StdOutLogContext = 'STDOUT';
+
+export const StdErrorLogContext = 'STDERR';

--- a/src/plugins/Logger.ts
+++ b/src/plugins/Logger.ts
@@ -13,7 +13,7 @@ class Logger {
     constructor(options: { loggerName: any; }) {
         this.options = options;
         this.loggerName = options && options.loggerName ? options.loggerName : 'default';
-        const levelConfig = Utils.getConfiguration(envVariableKeys.THUNDRRA_LAMBDA_LOG_LOGLEVEL);
+        const levelConfig = Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_LOG_LOGLEVEL);
         this.logLevel = levelConfig && logLevels[levelConfig] ? logLevels[levelConfig] : 0;
         this.levels = {          // higher number = higher priority
             trace: this.trace, // 0

--- a/test/plugins/console.shim.test.js
+++ b/test/plugins/console.shim.test.js
@@ -7,7 +7,7 @@ describe('Log plugin shim console', () => {
     const beforeInvocationData = createMockBeforeInvocationData();
     logPlugin.setPluginContext(pluginContext);
     logPlugin.beforeInvocation(beforeInvocationData);
-
+    logPlugin.logs = [];
     console.log('log');
     console.debug('debug');        
     console.info('info');
@@ -16,19 +16,39 @@ describe('Log plugin shim console', () => {
 
     it('should capture console.log statements', () => {  
         expect(logPlugin.logs.length).toBe(5);
+
         expect(logPlugin.logs[0].logLevel).toBe('LOG');
         expect(logPlugin.logs[0].logMessage).toBe('log');
+        expect(logPlugin.logs[0].logContextName).toBe('STDOUT');
 
         expect(logPlugin.logs[1].logLevel).toBe('DEBUG');
         expect(logPlugin.logs[1].logMessage).toBe('debug');
+        expect(logPlugin.logs[1].logContextName).toBe('STDOUT');
 
         expect(logPlugin.logs[2].logLevel).toBe('INFO');
         expect(logPlugin.logs[2].logMessage).toBe('info');
+        expect(logPlugin.logs[2].logContextName).toBe('STDOUT');
 
         expect(logPlugin.logs[3].logLevel).toBe('WARN');
         expect(logPlugin.logs[3].logMessage).toBe('warn');
+        expect(logPlugin.logs[3].logContextName).toBe('STDOUT');
 
         expect(logPlugin.logs[4].logLevel).toBe('ERROR');
         expect(logPlugin.logs[4].logMessage).toBe('error');
+        expect(logPlugin.logs[4].logContextName).toBe('STDERR');
+    });       
+});
+
+describe('Log plugin unshim console', () => {
+    const logPlugin = new LogPlugin();
+    const pluginContext = createMockPluginContext();
+    const beforeInvocationData = createMockBeforeInvocationData();
+    logPlugin.setPluginContext(pluginContext);
+    logPlugin.beforeInvocation(beforeInvocationData);
+    logPlugin.unShimConsole();
+
+    it('should not capture console.log statements after unshim', () => {  
+        console.log('log');
+        expect(logPlugin.logs.length).toBe(0);
     });       
 });

--- a/test/plugins/console.shim.test.js
+++ b/test/plugins/console.shim.test.js
@@ -1,0 +1,34 @@
+import LogPlugin from '../../dist/plugins/Log';
+import { createMockPluginContext, createMockBeforeInvocationData } from '../mocks/mocks';
+
+describe('Log plugin shim console', () => {
+    const logPlugin = new LogPlugin();
+    const pluginContext = createMockPluginContext();
+    const beforeInvocationData = createMockBeforeInvocationData();
+    logPlugin.setPluginContext(pluginContext);
+    logPlugin.beforeInvocation(beforeInvocationData);
+
+    console.log('log');
+    console.debug('debug');        
+    console.info('info');
+    console.warn('warn');
+    console.error('error');
+
+    it('should capture console.log statements', () => {  
+        expect(logPlugin.logs.length).toBe(5);
+        expect(logPlugin.logs[0].logLevel).toBe('LOG');
+        expect(logPlugin.logs[0].logMessage).toBe('log');
+
+        expect(logPlugin.logs[1].logLevel).toBe('DEBUG');
+        expect(logPlugin.logs[1].logMessage).toBe('debug');
+
+        expect(logPlugin.logs[2].logLevel).toBe('INFO');
+        expect(logPlugin.logs[2].logMessage).toBe('info');
+
+        expect(logPlugin.logs[3].logLevel).toBe('WARN');
+        expect(logPlugin.logs[3].logMessage).toBe('warn');
+
+        expect(logPlugin.logs[4].logLevel).toBe('ERROR');
+        expect(logPlugin.logs[4].logMessage).toBe('error');
+    });       
+});

--- a/test/plugins/log.test.js
+++ b/test/plugins/log.test.js
@@ -1,5 +1,5 @@
 import LogPlugin from '../../dist/plugins/Log';
-import { createMockReporter, createMockPluginContext, createMockBeforeInvocationData, createMockContext } from '../mocks/mocks';
+import { createMockReporter, createMockPluginContext, createMockBeforeInvocationData} from '../mocks/mocks';
 
 describe('LogPlugin', () => {
     describe('constructor', () => {


### PR DESCRIPTION
Thundra log plugin automatically shims console methods during initialization. 

Shimmed methods are `log`, `debug`, `info`, `warn`, `error`.

This feature can be disabled via `thundra_agent_lambda_log_console_shim_disable ` environment variable 