### PR TITLE
Fix AWS Integration issues with resource names and operation name being undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thundra/core",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/opentracing/sampler/CountAwareSampler.ts
+++ b/src/opentracing/sampler/CountAwareSampler.ts
@@ -16,8 +16,9 @@ class CountAwareSampler implements Sampler<null> {
     }
 
     isSampled(): boolean {
+        const result = this.counter % this.countFreq === 0;
         this.counter++;
-        return this.counter % this.countFreq === 0;
+        return result;
     }
 }
 

--- a/src/plugins/Invocation.ts
+++ b/src/plugins/Invocation.ts
@@ -66,7 +66,6 @@ class Invocation {
         this.invocationData.traceId = this.pluginContext.traceId;
 
         this.invocationData.tags['aws.lambda.memory_limit'] = this.pluginContext.maxMemory;
-        this.invocationData.tags['aws.lambda.invocation.request_id '] = originalContext.awsRequestId;
         this.invocationData.tags['aws.lambda.arn'] = originalContext.invokedFunctionArn;
         this.invocationData.tags['aws.lambda.invocation.coldstart'] = this.pluginContext.requestCount === 0;
         this.invocationData.tags['aws.region'] = this.pluginContext.applicationRegion;

--- a/src/plugins/Log.ts
+++ b/src/plugins/Log.ts
@@ -66,7 +66,7 @@ class Log {
         this.logData.tags['aws.lambda.memory_limit'] = parseInt(this.originalContext.memoryLimitInMB, 10);
         this.logData.tags['aws.lambda.log_group_name'] = this.originalContext.logGroupName;
         this.logData.tags['aws.lambda.log_stream_name'] = this.originalContext.logStreamName;
-        this.logData.tags['aws.lambda.invocation.request_id '] = this.originalContext.awsRequestId;
+        this.logData.tags['aws.lambda.invocation.request_id'] = this.originalContext.awsRequestId;
 
         if (Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_LOG_CONSOLE_DISABLE) !== 'true') {
             this.shimConsole();

--- a/src/plugins/Trace.ts
+++ b/src/plugins/Trace.ts
@@ -136,7 +136,7 @@ export class Trace {
         this.rootSpan.tags['aws.lambda.log_group_name'] = originalContext.logGroupName;
         this.rootSpan.tags['aws.lambda.name'] = originalContext.functionName;
         this.rootSpan.tags['aws.lambda.log_stream_name'] = originalContext.logStreamName;
-        this.rootSpan.tags['aws.lambda.invocation.request_id '] = originalContext.awsRequestId;
+        this.rootSpan.tags['aws.lambda.invocation.request_id'] = originalContext.awsRequestId;
         this.rootSpan.tags['aws.lambda.invocation.coldstart'] = this.pluginContext.requestCount === 0;
         this.rootSpan.tags['aws.lambda.invocation.request'] = this.getRequest(originalEvent);
 
@@ -289,6 +289,8 @@ export class Trace {
                 LambdaEventUtils.injectTriggerTagsForAPIGatewayProxy(span, originalEvent);
             } else if (lambdaEventType === LambdaEventType.Lambda) {
                 LambdaEventUtils.injectTriggerTagsForLambda(span, originalContext);
+            } else if (lambdaEventType === LambdaEventType.APIGatewayPassThrough) {
+                LambdaEventUtils.injectTriggerTagsForAPIGatewayPassThrough(span, originalEvent);
             }
         } catch (error) {
             ThundraLogger.getInstance().error('Cannot inject trigger tags. ' + error);

--- a/src/plugins/config/CountAwareSamplerConfig.ts
+++ b/src/plugins/config/CountAwareSamplerConfig.ts
@@ -1,4 +1,6 @@
 import BasePluginConfig from './BasePluginConfig';
+import Utils from '../utils/Utils';
+import { envVariableKeys } from '../../Constants';
 const koalas = require('koalas');
 
 class CountAwareSamplerConfig extends BasePluginConfig {
@@ -6,8 +8,11 @@ class CountAwareSamplerConfig extends BasePluginConfig {
 
     constructor(options: any) {
         options = options ? options : {};
-        super(koalas(options.enabled, false));
-        this.countFreq = options.countFreq;
+        super(koalas(options.enabled, true));
+
+        const freq = koalas(Utils.getConfiguration(
+            envVariableKeys.THUNDRA_AGENT_METRIC_COUNT_AWARE_SAMPLER_COUNT_FREQ) , options.countFreq, 100);
+        this.countFreq = parseInt(freq, 10);
     }
 }
 

--- a/src/plugins/config/MetricSamplerConfig.ts
+++ b/src/plugins/config/MetricSamplerConfig.ts
@@ -27,19 +27,24 @@ class MetricSamplerConfig {
     }
 
     isSampled(): boolean {
-        let isSampled = true;
+        if (!this.countAwareSampler &&
+            !this.timeAwareSampler && !this.customSampler) {
+                return true;
+        }
+
+        let isSampled = false;
 
         if (this.countAwareSampler) {
-            isSampled = this.countAwareSampler.isSampled();
+            isSampled = isSampled || this.countAwareSampler.isSampled();
         }
 
         if (this.timeAwareSampler) {
-            isSampled = this.timeAwareSampler.isSampled();
+            isSampled = isSampled || this.timeAwareSampler.isSampled();
         }
 
         if (this.customSampler) {
             if (typeof this.customSampler === 'function' && this.customSampler().isSampled) {
-                isSampled = this.customSampler().isSampled();
+                isSampled = isSampled || this.customSampler().isSampled();
             }
         }
 

--- a/src/plugins/config/TimeAwareSamplerConfig.ts
+++ b/src/plugins/config/TimeAwareSamplerConfig.ts
@@ -1,14 +1,20 @@
 
 import BasePluginConfig from './BasePluginConfig';
-
+import { envVariableKeys } from '../../Constants';
+import Utils from '../utils/Utils';
 const koalas = require('koalas');
+
 class TimeAwareSamplerConfig extends BasePluginConfig {
     timeFreq: number;
 
     constructor(options: any) {
         options = options ? options : {};
-        super(koalas(options.enabled, false));
-        this.timeFreq = options.timeFreq;
+        super(koalas(options.enabled, true));
+
+        const freq = koalas(Utils.getConfiguration(
+            envVariableKeys.THUNDRA_AGENT_METRIC_TIME_AWARE_SAMPLER_TIME_FREQ) , options.timeFreq, 300000);
+
+        this.timeFreq = parseInt(freq, 10);
     }
 }
 

--- a/src/plugins/integrations/HttpIntegration.ts
+++ b/src/plugins/integrations/HttpIntegration.ts
@@ -1,10 +1,13 @@
 import Integration from './Integration';
 import ThundraTracer from '../../opentracing/Tracer';
 import * as opentracing from 'opentracing';
-import { HttpTags, SpanTags, SpanTypes, DomainNames, ClassNames, envVariableKeys,
-  LAMBDA_APPLICATION_CLASS_NAME, LAMBDA_APPLICATION_DOMAIN_NAME } from '../../Constants';
+import {
+  HttpTags, SpanTags, SpanTypes, DomainNames, ClassNames, envVariableKeys,
+  LAMBDA_APPLICATION_CLASS_NAME, LAMBDA_APPLICATION_DOMAIN_NAME,
+} from '../../Constants';
 import Utils from '../utils/Utils';
 import * as url from 'url';
+import ThundraLogger from '../../ThundraLogger';
 
 const shimmer = require('shimmer');
 const Hook = require('require-in-the-middle');
@@ -32,14 +35,14 @@ class HttpIntegration implements Integration {
   static isValidUrl(host: string): boolean {
 
     if (host.indexOf('amazonaws.com') !== -1 &&
-        host.indexOf('execute-api') !== -1) {
+      host.indexOf('execute-api') !== -1) {
       return true;
     }
 
     if (host === 'api.thundra.io' ||
-        host === 'serverless.com' ||
-        host.indexOf('amazonaws.com') !== -1) {
-          return false;
+      host === 'serverless.com' ||
+      host.indexOf('amazonaws.com') !== -1) {
+      return false;
     }
 
     return true;
@@ -48,73 +51,77 @@ class HttpIntegration implements Integration {
   wrap(lib: any, config: any): void {
     function wrapper(request: any) {
       return function requestWrapper(options: any, callback: any) {
+        try {
+          const tracer = ThundraTracer.getInstance();
+          const method = (options.method || 'GET').toUpperCase();
+          options = typeof options === 'string' ? url.parse(options) : options;
+          const host = options.hostname || options.host || 'localhost';
+          const path = options.path || options.pathname || '/';
+          const queryParams = path.split('?').length > 1 ? path.split('?')[1] : '';
 
-        const tracer = ThundraTracer.getInstance();
-        const method = (options.method || 'GET').toUpperCase();
-        options = typeof options === 'string' ? url.parse(options) : options;
-        const host = options.hostname || options.host || 'localhost';
-        const path = options.path || options.pathname || '/';
-        const queryParams = path.split('?').length > 1 ? path.split('?')[1] : '';
+          if (!HttpIntegration.isValidUrl(host)) {
+            return request.apply(this, [options, callback]);
+          }
 
-        if (!HttpIntegration.isValidUrl(host)) {
+          const parentSpan = tracer.getActiveSpan();
+          const span = tracer._startSpan(host + path, {
+            childOf: parentSpan,
+            domainName: DomainNames.API,
+            className: ClassNames.HTTP,
+            disableActiveStart: true,
+          });
+
+          if (!(Utils.getConfiguration(envVariableKeys.DISABLE_SPAN_CONTEXT_INJECTION) === 'true')) {
+            const headers = options.headers ? options.headers : {};
+            tracer.inject(span.spanContext, opentracing.FORMAT_TEXT_MAP, headers);
+            options.headers = headers;
+          }
+
+          span.addTags({
+            [SpanTags.OPERATION_TYPE]: 'CALL',
+            [SpanTags.SPAN_TYPE]: SpanTypes.HTTP,
+            [HttpTags.HTTP_METHOD]: method,
+            [HttpTags.HTTP_HOST]: host,
+            [HttpTags.HTTP_PATH]: path.split('?')[0],
+            [HttpTags.HTTP_URL]: host + path,
+            [HttpTags.QUERY_PARAMS]: queryParams,
+            [SpanTags.TOPOLOGY_VERTEX]: true,
+            [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
+            [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
+            [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
+          });
+
+          const req = request.call(this, options, callback);
+
+          req.on('socket', () => {
+            if (req.listenerCount('response') === 1) {
+              req.on('response', (res: any) => res.resume());
+            }
+          });
+
+          req.on('response', (res: any) => {
+            span.setTag(HttpTags.HTTP_STATUS, res.statusCode);
+            res.on('end', () => span.close());
+            span.close();
+          });
+
+          req.on('error', (err: any) => {
+            const parseError = Utils.parseError(err);
+
+            span.setTag('error', true);
+            span.setTag('error.kind', parseError.errorType);
+            span.setTag('error.message', parseError.errorMessage);
+            span.setTag('error.stack', parseError.stack);
+            span.setTag('error.code', parseError.code);
+
+            span.close();
+          });
+
+          return req;
+        } catch (error) {
+          ThundraLogger.getInstance().error(error);
           return request.apply(this, [options, callback]);
         }
-
-        const parentSpan = tracer.getActiveSpan();
-        const span = tracer._startSpan(host + path, {
-          childOf: parentSpan,
-          domainName: DomainNames.API,
-          className: ClassNames.HTTP,
-          disableActiveStart: true,
-        });
-
-        if (!(Utils.getConfiguration(envVariableKeys.DISABLE_SPAN_CONTEXT_INJECTION) === 'true') ) {
-          const headers = options.headers ? options.headers : {};
-          tracer.inject(span.spanContext, opentracing.FORMAT_TEXT_MAP, headers);
-          options.headers = headers;
-        }
-
-        span.addTags({
-          [SpanTags.OPERATION_TYPE]: 'CALL',
-          [SpanTags.SPAN_TYPE]: SpanTypes.HTTP,
-          [HttpTags.HTTP_METHOD]: method,
-          [HttpTags.HTTP_HOST]: host,
-          [HttpTags.HTTP_PATH]: path.split('?')[0],
-          [HttpTags.HTTP_URL]: host + path,
-          [HttpTags.QUERY_PARAMS]: queryParams,
-          [SpanTags.TOPOLOGY_VERTEX]: true,
-          [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
-          [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
-          [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
-        });
-
-        const req = request.call(this, options, callback);
-
-        req.on('socket', () => {
-          if (req.listenerCount('response') === 1) {
-            req.on('response', (res: any) => res.resume());
-          }
-        });
-
-        req.on('response', (res: any) => {
-          span.setTag(HttpTags.HTTP_STATUS, res.statusCode);
-          res.on('end', () => span.close());
-          span.close();
-        });
-
-        req.on('error', (err: any) => {
-          const parseError = Utils.parseError(err);
-
-          span.setTag('error', true);
-          span.setTag('error.kind', parseError.errorType);
-          span.setTag('error.message', parseError.errorMessage);
-          span.setTag('error.stack', parseError.stack);
-          span.setTag('error.code', parseError.code);
-
-          span.close();
-        });
-
-        return req;
       };
     }
 

--- a/src/plugins/integrations/HttpIntegration.ts
+++ b/src/plugins/integrations/HttpIntegration.ts
@@ -78,7 +78,7 @@ class HttpIntegration implements Integration {
           }
 
           span.addTags({
-            [SpanTags.OPERATION_TYPE]: 'CALL',
+            [SpanTags.OPERATION_TYPE]: method,
             [SpanTags.SPAN_TYPE]: SpanTypes.HTTP,
             [HttpTags.HTTP_METHOD]: method,
             [HttpTags.HTTP_HOST]: host,

--- a/src/plugins/integrations/PostgreIntegration.ts
+++ b/src/plugins/integrations/PostgreIntegration.ts
@@ -1,7 +1,9 @@
 import Integration from './Integration';
 import ThundraTracer from '../../opentracing/Tracer';
-import { DBTags, SpanTags, SpanTypes, DomainNames, ClassNames, DBTypes,
-  SQLQueryOperationTypes, LAMBDA_APPLICATION_DOMAIN_NAME, LAMBDA_APPLICATION_CLASS_NAME } from '../../Constants';
+import {
+  DBTags, SpanTags, SpanTypes, DomainNames, ClassNames, DBTypes,
+  SQLQueryOperationTypes, LAMBDA_APPLICATION_DOMAIN_NAME, LAMBDA_APPLICATION_CLASS_NAME,
+} from '../../Constants';
 import Utils from '../utils/Utils';
 import ModuleVersionValidator from './ModuleVersionValidator';
 import ThundraLogger from '../../ThundraLogger';
@@ -41,66 +43,69 @@ class PostgreIntegration implements Integration {
   wrap(lib: any, config: any) {
     function wrapper(query: any, args: any) {
       return function queryWrapper() {
+        try {
+          const tracer = ThundraTracer.getInstance();
+          const parentSpan = tracer.getActiveSpan();
 
-        const tracer = ThundraTracer.getInstance();
-        const parentSpan = tracer.getActiveSpan();
-
-        const params = this.connectionParameters;
-        const span = tracer._startSpan(params.database, {
-          childOf: parentSpan,
-          domainName: DomainNames.DB,
-          className: ClassNames.RDB,
-          disableActiveStart: true,
-        });
-
-        if (params) {
-          span.addTags({
-            [SpanTags.SPAN_TYPE]: SpanTypes.RDB,
-            [DBTags.DB_INSTANCE]: params.database,
-            [DBTags.DB_USER]: params.user,
-            [DBTags.DB_HOST]: params.host,
-            [DBTags.DB_PORT]: params.port,
-            [DBTags.DB_TYPE]: DBTypes.PG,
-            [SpanTags.TOPOLOGY_VERTEX]: true,
-            [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
-            [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
-            [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
+          const params = this.connectionParameters;
+          const span = tracer._startSpan(params.database, {
+            childOf: parentSpan,
+            domainName: DomainNames.DB,
+            className: ClassNames.RDB,
+            disableActiveStart: true,
           });
-        }
 
-        const pgQuery = query.apply(this, arguments);
-
-        let statement = pgQuery.text;
-        statement = Utils.replaceArgs(statement, pgQuery.values);
-
-        if (statement) {
-          const statementType = statement.split(' ')[0].toUpperCase();
-          span.addTags({
-            [DBTags.DB_STATEMENT_TYPE]: statementType,
-            [DBTags.DB_STATEMENT]: statement,
-            [SpanTags.OPERATION_TYPE]: SQLQueryOperationTypes[statementType] ? SQLQueryOperationTypes[statementType] : 'READ',
-          });
-        }
-
-        const originalCallback = pgQuery.callback;
-
-        pgQuery.callback = (err: any, res: any) => {
-          if (err) {
-            const parseError = Utils.parseError(err);
-            span.setTag('error', true);
-            span.setTag('error.kind', parseError.errorType);
-            span.setTag('error.message', parseError.errorMessage);
+          if (params) {
+            span.addTags({
+              [SpanTags.SPAN_TYPE]: SpanTypes.RDB,
+              [DBTags.DB_INSTANCE]: params.database,
+              [DBTags.DB_USER]: params.user,
+              [DBTags.DB_HOST]: params.host,
+              [DBTags.DB_PORT]: params.port,
+              [DBTags.DB_TYPE]: DBTypes.PG,
+              [SpanTags.TOPOLOGY_VERTEX]: true,
+              [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
+              [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
+              [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
+            });
           }
 
-          span.close();
+          const pgQuery = query.apply(this, arguments);
 
-          if (originalCallback) {
-            originalCallback(err, res);
+          let statement = pgQuery.text;
+          statement = Utils.replaceArgs(statement, pgQuery.values);
+
+          if (statement) {
+            const statementType = statement.split(' ')[0].toUpperCase();
+            span.addTags({
+              [DBTags.DB_STATEMENT_TYPE]: statementType,
+              [DBTags.DB_STATEMENT]: statement,
+              [SpanTags.OPERATION_TYPE]: SQLQueryOperationTypes[statementType] ? SQLQueryOperationTypes[statementType] : 'READ',
+            });
           }
-        };
 
-        return pgQuery;
+          const originalCallback = pgQuery.callback;
 
+          pgQuery.callback = (err: any, res: any) => {
+            if (err) {
+              const parseError = Utils.parseError(err);
+              span.setTag('error', true);
+              span.setTag('error.kind', parseError.errorType);
+              span.setTag('error.message', parseError.errorMessage);
+            }
+
+            span.close();
+
+            if (originalCallback) {
+              originalCallback(err, res);
+            }
+          };
+
+          return pgQuery;
+        } catch (error) {
+          ThundraLogger.getInstance().error(error);
+          query.apply(this, arguments);
+        }
       };
     }
 

--- a/src/plugins/integrations/RedisIntegration.ts
+++ b/src/plugins/integrations/RedisIntegration.ts
@@ -1,7 +1,9 @@
 import Integration from './Integration';
 import ThundraTracer from '../../opentracing/Tracer';
-import { SpanTags, RedisTags, RedisCommandTypes, SpanTypes, DomainNames,
-  ClassNames, DBTypes, DBTags, LAMBDA_APPLICATION_DOMAIN_NAME, LAMBDA_APPLICATION_CLASS_NAME } from '../../Constants';
+import {
+  SpanTags, RedisTags, RedisCommandTypes, SpanTypes, DomainNames,
+  ClassNames, DBTypes, DBTags, LAMBDA_APPLICATION_DOMAIN_NAME, LAMBDA_APPLICATION_CLASS_NAME,
+} from '../../Constants';
 import Utils from '../utils/Utils';
 import { DB_TYPE, DB_INSTANCE } from 'opentracing/lib/ext/tags';
 import ModuleVersionValidator from './ModuleVersionValidator';
@@ -40,66 +42,71 @@ class RedisIntegration implements Integration {
 
     function wrapper(internalSendCommand: any) {
       return function internalSendCommandWrapper(options: any) {
-        const tracer = ThundraTracer.getInstance();
+        try {
+          const tracer = ThundraTracer.getInstance();
 
-        if (!options) {
-          return internalSendCommand.call(this, options);
-        }
-
-        const parentSpan = tracer.getActiveSpan();
-        let host = 'localhost';
-        let port = '6379';
-        let command = '';
-
-        if (this.connection_options) {
-          host = String(this.connection_options.host);
-          port = String(this.connection_options.port);
-          command = options.command.toUpperCase();
-        }
-
-        const operationType = RedisCommandTypes[command] ? RedisCommandTypes[command] : 'READ';
-
-        const span = tracer._startSpan(host, {
-          childOf: parentSpan,
-          domainName: DomainNames.CACHE,
-          className: ClassNames.REDIS,
-          disableActiveStart: true,
-          tags: {
-            [SpanTags.SPAN_TYPE]: SpanTypes.REDIS,
-            [DB_TYPE]: DBTypes.REDIS,
-            [DB_INSTANCE]: host,
-            [DBTags.DB_STATEMENT_TYPE]: operationType,
-            [RedisTags.REDIS_HOST]: host,
-            [RedisTags.REDIS_PORT]: port,
-            [RedisTags.REDIS_COMMAND]: command,
-            [RedisTags.REDIS_COMMAND_TYPE]: operationType,
-            [RedisTags.REDIS_COMMAND_ARGS]: options.args.join(','),
-            [SpanTags.OPERATION_TYPE]: operationType,
-            [SpanTags.TOPOLOGY_VERTEX]: true,
-            [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
-            [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
-            [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
-          },
-        });
-
-        const originalCallback = options.callback;
-
-        const wrappedCallback = (err: any, res: any) => {
-          if (err) {
-            const parseError = Utils.parseError(err);
-            span.setTag('error', true);
-            span.setTag('error.kind', parseError.errorType);
-            span.setTag('error.message', parseError.errorMessage);
+          if (!options) {
+            return internalSendCommand.call(this, options);
           }
 
-          span.close();
+          const parentSpan = tracer.getActiveSpan();
+          let host = 'localhost';
+          let port = '6379';
+          let command = '';
 
-          originalCallback(err, res);
-        };
+          if (this.connection_options) {
+            host = String(this.connection_options.host);
+            port = String(this.connection_options.port);
+            command = options.command.toUpperCase();
+          }
 
-        options.callback = wrappedCallback;
+          const operationType = RedisCommandTypes[command] ? RedisCommandTypes[command] : 'READ';
 
-        return internalSendCommand.call(this, options);
+          const span = tracer._startSpan(host, {
+            childOf: parentSpan,
+            domainName: DomainNames.CACHE,
+            className: ClassNames.REDIS,
+            disableActiveStart: true,
+            tags: {
+              [SpanTags.SPAN_TYPE]: SpanTypes.REDIS,
+              [DB_TYPE]: DBTypes.REDIS,
+              [DB_INSTANCE]: host,
+              [DBTags.DB_STATEMENT_TYPE]: operationType,
+              [RedisTags.REDIS_HOST]: host,
+              [RedisTags.REDIS_PORT]: port,
+              [RedisTags.REDIS_COMMAND]: command,
+              [RedisTags.REDIS_COMMAND_TYPE]: operationType,
+              [RedisTags.REDIS_COMMAND_ARGS]: options.args.join(','),
+              [SpanTags.OPERATION_TYPE]: operationType,
+              [SpanTags.TOPOLOGY_VERTEX]: true,
+              [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
+              [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
+              [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
+            },
+          });
+
+          const originalCallback = options.callback;
+
+          const wrappedCallback = (err: any, res: any) => {
+            if (err) {
+              const parseError = Utils.parseError(err);
+              span.setTag('error', true);
+              span.setTag('error.kind', parseError.errorType);
+              span.setTag('error.message', parseError.errorMessage);
+            }
+
+            span.close();
+
+            originalCallback(err, res);
+          };
+
+          options.callback = wrappedCallback;
+
+          return internalSendCommand.call(this, options);
+        } catch (error) {
+          ThundraLogger.getInstance().error(error);
+          internalSendCommand.call(this, options);
+        }
       };
     }
 

--- a/src/plugins/utils/Utils.ts
+++ b/src/plugins/utils/Utils.ts
@@ -167,17 +167,20 @@ class Utils {
 
     static getDynamoDBTableName(request: any): string {
         let tableName = 'DynamoEngine';
-        if (request.params.TableName) {
+
+        if (request.params && request.params.TableName) {
             tableName = request.params.TableName;
         }
-        if (request.params.RequestItems) {
+
+        if (request.params && request.params.RequestItems) {
             tableName = Object.keys(request.params.RequestItems).join(',');
         }
+
         return tableName;
     }
 
     static getQueueName(url: any): string {
-        return url ? url.split('/').pop() : '';
+        return url ? url.split('/').pop() : null;
     }
 
     static getTopicName(topicArn: any): string {

--- a/src/plugins/utils/Utils.ts
+++ b/src/plugins/utils/Utils.ts
@@ -166,7 +166,7 @@ class Utils {
     }
 
     static getDynamoDBTableName(request: any): string {
-        let tableName = 'DynamoEngine';
+        let tableName;
 
         if (request.params && request.params.TableName) {
             tableName = request.params.TableName;

--- a/test/integration/aws.integration.test.js
+++ b/test/integration/aws.integration.test.js
@@ -15,8 +15,12 @@ describe('AWS Integration', () => {
 
         return AWS.dynamo(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+            
+            expect(span.operationName).toBe('test-table');
+
             expect(span.className).toBe('AWS-DynamoDB');
             expect(span.domainName).toBe('DB');
+
             expect(span.tags['db.type']).toBe('aws-dynamodb');
             expect(span.tags['db.instance']).toBe('dynamodb.us-west-2.amazonaws.com');
             expect(span.tags['db.statement.type']).toBe('READ');
@@ -31,7 +35,7 @@ describe('AWS Integration', () => {
         });
     });
 
-    test('should instrument AWS S3 calls ', () => { 
+    test('should instrument AWS S3 GetObject call ', () => { 
         const integration = new AWSIntegration({});
         const sdk = require('aws-sdk');
 
@@ -40,14 +44,46 @@ describe('AWS Integration', () => {
         const tracer = new ThundraTracer();
         tracer.functionName = 'functionName';
 
-        return AWS.s3(sdk).then(() => {
+        return AWS.s3GetObject(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+
+            expect(span.operationName).toBe('test');
+
             expect(span.className).toBe('AWS-S3');
             expect(span.domainName).toBe('Storage');
+
             expect(span.tags['operation.type']).toBe('READ');
             expect(span.tags['aws.s3.bucket.name']).toBe('test');
             expect(span.tags['aws.request.name']).toBe('getObject');
             expect(span.tags['aws.s3.object.name']).toBe('test.txt');
+            expect(span.tags['topology.vertex']).toEqual(true);
+            expect(span.tags['trigger.domainName']).toEqual('API');
+            expect(span.tags['trigger.className']).toEqual('AWS-Lambda');
+            expect(span.tags['trigger.operationNames']).toEqual(['functionName']);
+        });
+    });
+
+    test('should instrument AWS S3 ListBucket call ', () => { 
+        const integration = new AWSIntegration({});
+        const sdk = require('aws-sdk');
+
+        integration.wrap(sdk, {});
+        
+        const tracer = new ThundraTracer();
+        tracer.functionName = 'functionName';
+
+        return AWS.s3ListBuckets(sdk).then(() => {
+            const span = tracer.getRecorder().spanList[0];
+
+            expect(span.operationName).toBe('AWSServiceRequest');
+
+            expect(span.className).toBe('AWS-S3');
+            expect(span.domainName).toBe('Storage');
+
+            expect(span.tags['operation.type']).toBe('READ');
+            expect(span.tags['aws.s3.bucket.name']).not.toBeTruthy();
+            expect(span.tags['aws.request.name']).toBe('listBuckets');
+            expect(span.tags['aws.s3.object.name']).not.toBeTruthy();
             expect(span.tags['topology.vertex']).toEqual(true);
             expect(span.tags['trigger.domainName']).toEqual('API');
             expect(span.tags['trigger.className']).toEqual('AWS-Lambda');
@@ -66,8 +102,12 @@ describe('AWS Integration', () => {
 
         return AWS.lambda(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+
+            expect(span.operationName).toBe('Test');
+
             expect(span.className).toBe('AWS-Lambda');
             expect(span.domainName).toBe('API');
+
             expect(span.tags['aws.lambda.name']).toBe('Test');
             expect(span.tags['aws.lambda.qualifier']).toBe(undefined);
             expect(span.tags['aws.lambda.invocation.payload']).toEqual('{ "name" : "thundra" }');
@@ -91,8 +131,12 @@ describe('AWS Integration', () => {
 
         return AWS.sqs(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+
+            expect(span.operationName).toBe('testqueue');
+
             expect(span.className).toBe('AWS-SQS');
             expect(span.domainName).toBe('Messaging');
+
             expect(span.tags['aws.request.name']).toBe('sendMessage');
             expect(span.tags['aws.sqs.queue.name']).toBe('testqueue');
             expect(span.tags['operation.type']).toBe('WRITE');
@@ -114,12 +158,14 @@ describe('AWS Integration', () => {
 
         return AWS.sqs_list_queue(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+            
             expect(span.operationName).toBe('AWSServiceRequest');
 
             expect(span.className).toBe('AWS-SQS');
             expect(span.domainName).toBe('Messaging');
+
             expect(span.tags['aws.request.name']).toBe('listQueues');
-            expect(span.tags['aws.sqs.queue.name']).toBe('AWSServiceRequest');
+            expect(span.tags['aws.sqs.queue.name']).not.toBeTruthy();
             expect(span.tags['operation.type']).toBe('READ');
             expect(span.tags['topology.vertex']).not.toBeTruthy();
             expect(span.tags['trigger.domainName']).not.toBeTruthy();
@@ -129,7 +175,7 @@ describe('AWS Integration', () => {
     });
   
     
-    test('should instrument AWS SNS calls ', () => { 
+    test('should instrument AWS SNS publish calls ', () => { 
         const integration = new AWSIntegration({});
         const sdk = require('aws-sdk');
 
@@ -140,8 +186,12 @@ describe('AWS Integration', () => {
 
         return AWS.sns(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+
+            expect(span.operationName).toBe('TEST_TOPIC');
+
             expect(span.className).toBe('AWS-SNS');
             expect(span.domainName).toBe('Messaging');
+
             expect(span.tags['aws.request.name']).toBe('publish');
             expect(span.tags['aws.sns.topic.name']).toBe('TEST_TOPIC');
             expect(span.tags['operation.type']).toBe('WRITE');
@@ -149,6 +199,30 @@ describe('AWS Integration', () => {
             expect(span.tags['trigger.domainName']).toEqual('API');
             expect(span.tags['trigger.className']).toEqual('AWS-Lambda');
             expect(span.tags['trigger.operationNames']).toEqual(['functionName']);
+        });
+    }); 
+
+
+    test('should instrument AWS SNS  call without publish', () => { 
+        const integration = new AWSIntegration({});
+        const sdk = require('aws-sdk');
+
+        integration.wrap(sdk, {});
+        
+        const tracer = new ThundraTracer();
+        tracer.functionName = 'functionName';
+
+        return AWS.sns_checkIfPhoneNumberIsOptedOut(sdk).then(() => {
+            const span = tracer.getRecorder().spanList[0];
+
+            expect(span.operationName).toBe('AWSServiceRequest');
+
+            expect(span.className).toBe('AWS-SNS');
+            expect(span.domainName).toBe('Messaging');
+
+            expect(span.tags['aws.request.name']).toBe('checkIfPhoneNumberIsOptedOut');
+            expect(span.tags['aws.sns.topic.name']).toBe(undefined);
+            expect(span.tags['operation.type']).toBe('READ');
         });
     }); 
     
@@ -163,8 +237,11 @@ describe('AWS Integration', () => {
 
         return AWS.kinesis(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+            expect(span.operationName).toBe('STRING_VALUE');
+
             expect(span.className).toBe('AWS-Kinesis');
             expect(span.domainName).toBe('Stream');
+
             expect(span.tags['aws.request.name']).toBe('putRecord');
             expect(span.tags['aws.kinesis.stream.name']).toBe('STRING_VALUE');
             expect(span.tags['operation.type']).toBe('WRITE');
@@ -186,8 +263,11 @@ describe('AWS Integration', () => {
 
         return AWS.firehose(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
+            expect(span.operationName).toBe('STRING_VALUE');
+
             expect(span.className).toBe('AWS-Firehose');
             expect(span.domainName).toBe('Stream');
+
             expect(span.tags['aws.request.name']).toBe('putRecord');
             expect(span.tags['aws.firehose.stream.name']).toBe('STRING_VALUE');
             expect(span.tags['operation.type']).toBe('WRITE');

--- a/test/integration/aws.integration.test.js
+++ b/test/integration/aws.integration.test.js
@@ -166,7 +166,7 @@ describe('AWS Integration', () => {
 
             expect(span.tags['aws.request.name']).toBe('listQueues');
             expect(span.tags['aws.sqs.queue.name']).not.toBeTruthy();
-            expect(span.tags['operation.type']).toBe('READ');
+            expect(span.tags['operation.type']).toBe('');
             expect(span.tags['topology.vertex']).not.toBeTruthy();
             expect(span.tags['trigger.domainName']).not.toBeTruthy();
             expect(span.tags['trigger.className']).not.toBeTruthy();
@@ -222,7 +222,7 @@ describe('AWS Integration', () => {
 
             expect(span.tags['aws.request.name']).toBe('checkIfPhoneNumberIsOptedOut');
             expect(span.tags['aws.sns.topic.name']).toBe(undefined);
-            expect(span.tags['operation.type']).toBe('READ');
+            expect(span.tags['operation.type']).toBe('');
         });
     }); 
     

--- a/test/integration/http.integration.test.js
+++ b/test/integration/http.integration.test.js
@@ -18,7 +18,7 @@ describe('HTTP integration', () => {
             expect(span.className).toBe('HTTP');
             expect(span.domainName).toBe('API');
 
-            expect(span.tags['operation.type']).toBe('CALL');
+            expect(span.tags['operation.type']).toBe('GET');
             expect(span.tags['http.method']).toBe('GET');
             expect(span.tags['http.host']).toBe('jsonplaceholder.typicode.com');
             expect(span.tags['http.path']).toBe('/users/1');

--- a/test/integration/mysql.integration.test.js
+++ b/test/integration/mysql.integration.test.js
@@ -16,7 +16,7 @@ describe('MySQL2 Integration', () => {
 
         return mysql.select(sdk).then((data) => {
             const span = tracer.getRecorder().spanList[0];
-            expect(span.className).toBe('RDB');
+            expect(span.className).toBe('MYSQL');
             expect(span.domainName).toBe('DB');
 
             expect(span.tags['operation.type']).toBe('READ');

--- a/test/integration/pg.integration.test.js
+++ b/test/integration/pg.integration.test.js
@@ -16,7 +16,7 @@ describe('PostgreSQL Integration', () => {
         return PG.select(sdk).then((data) => {
             const span = tracer.getRecorder().spanList[0];
 
-            expect(span.className).toBe('RDB');
+            expect(span.className).toBe('PG');
             expect(span.domainName).toBe('DB');
 
             expect(span.tags['operation.type']).toBe('READ');

--- a/test/integration/utils/aws.integration.utils.js
+++ b/test/integration/utils/aws.integration.utils.js
@@ -19,7 +19,7 @@ module.exports.dynamo = (AWS) => {
     });
 };
 
-module.exports.s3 = (AWS) => {
+module.exports.s3GetObject = (AWS) => {
     return new Promise((resolve) => {
         AWS.config.update({ region: 'us-west-2' });
         const s3 = new AWS.S3();
@@ -29,6 +29,22 @@ module.exports.s3 = (AWS) => {
         };
 
         s3.getObject(getParams, function (err, data) {
+            if (err) {
+                // Resolve even though there is an error.
+                return resolve(err);
+            }
+            return resolve(data);
+        });
+    });
+};
+
+module.exports.s3ListBuckets = (AWS) => {
+    return new Promise((resolve) => {
+        AWS.config.update({ region: 'us-west-2' });
+        const s3 = new AWS.S3();
+        var params = {};
+
+        s3.listBuckets(params, function (err, data) {
             if (err) {
                 // Resolve even though there is an error.
                 return resolve(err);
@@ -112,6 +128,24 @@ module.exports.sns = (AWS) => {
     });
 };
 
+module.exports.sns_checkIfPhoneNumberIsOptedOut = (AWS) => {
+    return new Promise((resolve) => {
+        AWS.config.update({ region: 'us-west-2' });
+        const sns = new AWS.SNS({ apiVersion: '2010-03-31' });
+        const params = {
+            phoneNumber: 'STRING_VALUE' /* required */
+        };
+
+        sns.checkIfPhoneNumberIsOptedOut(params, function (err, data) {
+            if (err) {
+                // Resolve even though there is an error.
+                return resolve(err);
+            }
+            return resolve(data);
+        });
+    });
+};
+
 module.exports.kinesis = (AWS) => {
     return new Promise((resolve) => {
         AWS.config.update({ region: 'us-west-2' });
@@ -154,5 +188,3 @@ module.exports.firehose = (AWS) => {
         });
     });
 };
-
-

--- a/test/mocks/aws.events.mocks.js
+++ b/test/mocks/aws.events.mocks.js
@@ -1,4 +1,4 @@
-const createKinesisMockEvent = () => {
+const createMockKinesisEvent = () => {
     return {
         Records: [
             {
@@ -21,7 +21,7 @@ const createKinesisMockEvent = () => {
     };
 };
 
-const createFirehoseMockEvent = () => {
+const createMockFirehoseEvent = () => {
     return {
         invocationId: 'invocationIdExample',
         deliveryStreamArn: 'arn:aws:kinesis:EXAMPLE',
@@ -36,7 +36,7 @@ const createFirehoseMockEvent = () => {
     };
 };
 
-const createDynamoDBMockEvent = () => {
+const createMockDynamoDBEvent = () => {
     return {
         Records: [
             {
@@ -287,16 +287,66 @@ const createMockAPIGatewayProxyEvent = () => {
     };
 };
 
+const createMockAPIGatewayPassThroughRequest = () => {
+    return {
+        'body-json': {},
+        'params': {
+            'path': {},
+            'querystring': {},
+            'header': {
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                'Accept-Encoding': 'br, gzip, deflate',
+                'Accept-Language': 'tr-tr',
+                'CloudFront-Forwarded-Proto': 'https',
+                'CloudFront-Is-Desktop-Viewer': 'true',
+                'CloudFront-Is-Mobile-Viewer': 'false',
+                'CloudFront-Is-SmartTV-Viewer': 'false',
+                'CloudFront-Is-Tablet-Viewer': 'false',
+                'CloudFront-Viewer-Country': 'TR',
+                'Host': 'random.execute-api.us-west-2.amazonaws.com',
+                'User-Agent': 'Mozilla/5.0 ',
+                'Via': '2.0 7c2d73d3cd46e357090188fa2946f746.cloudfront.net (CloudFront)',
+                'X-Amz-Cf-Id': '2oERVyfE28F7rylVV0ZOdEBnmogTSblZNOrSON_vGJFBweD1tIM-dg==',
+                'X-Amzn-Trace-Id': 'Root=1-5c3d8b9e-794ee8faf33ffce551c0146b',
+                'X-Forwarded-Port': '443',
+                'X-Forwarded-Proto': 'https'
+            }
+        },
+        'stage-variables': {},
+        'context': {
+            'account-id': '',
+            'api-id': 'random',
+            'api-key': '',
+            'authorizer-principal-id': '',
+            'caller': '',
+            'cognito-authentication-provider': '',
+            'cognito-authentication-type': '',
+            'cognito-identity-id': '',
+            'cognito-identity-pool-id': '',
+            'http-method': 'GET',
+            'stage': 'dev',
+            'source-ip': '',
+            'user': '',
+            'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14)',
+            'user-arn': '',
+            'request-id': '27eca8d1-1897-11e9-9eed-0d1fbe8bcba6',
+            'resource-id': '3ggrja',
+            'resource-path': '/hello'
+        }
+    };
+};
+
 
 module.exports = {
     createMockAPIGatewayProxyEvent,
+    createMockAPIGatewayPassThroughRequest,
     createMockCloudFrontEvent,
     createMockCloudWatchLogEvent,
     createMockCloudWatchScheduledEvent,
     createMockS3Event,
     createMockSQSEvent,
     createMockSNSEvent,
-    createDynamoDBMockEvent,
-    createFirehoseMockEvent,
-    createKinesisMockEvent,
+    createMockDynamoDBEvent,
+    createMockFirehoseEvent,
+    createMockKinesisEvent,
 };

--- a/test/opentracing/sampler.test.js
+++ b/test/opentracing/sampler.test.js
@@ -65,7 +65,7 @@ describe('CountAwareSampler with count frequency 5', () => {
     let sampledCount = 0;
 
     test('should sample 2 of 10 calls', () => {
-        for (let sample = 0; sample <= 10; sample++) {
+        for (let sample = 0; sample < 10; sample++) {
             if (sampler.isSampled()) {
                 sampledCount++;
             }

--- a/test/plugins/invocation.test.js
+++ b/test/plugins/invocation.test.js
@@ -83,7 +83,6 @@ describe('Invocation', () => {
             expect(invocation.invocationData.tags).toEqual({
                 'aws.lambda.arn': 'arn:aws:lambda:us-west-2:123456789123:function:test',
                 'aws.lambda.invocation.coldstart': true,
-                'aws.lambda.invocation.request_id ': 'awsRequestId',
                 'aws.lambda.invocation.timeout': false,
                 'aws.lambda.log_group_name': '/aws/lambda/test',
                 'aws.lambda.log_stream_name': '2018/03/07/[$LATEST]test',

--- a/test/plugins/metric.config.test.js
+++ b/test/plugins/metric.config.test.js
@@ -1,0 +1,36 @@
+import MetricConfig from '../../dist/plugins/config/MetricConfig';
+import {envVariableKeys} from '../../dist/Constants';
+
+describe('default Metric Config', () => {
+    const config = new MetricConfig();
+
+    it('Should enable default sampling rules',() => {
+        expect(config.enabled).toBe(true);
+        
+        expect(config.samplerConfig.countAwareSamplerConfig.enabled).toEqual(true);
+        expect(config.samplerConfig.countAwareSamplerConfig.countFreq).toEqual(100);
+
+        expect(config.samplerConfig.timeAwareSamplerConfig.enabled).toEqual(true);
+        expect(config.samplerConfig.timeAwareSamplerConfig.timeFreq).toEqual(300000);
+    });
+});
+
+describe('default Metric Config', () => {
+    process.env[envVariableKeys.THUNDRA_AGENT_METRIC_COUNT_AWARE_SAMPLER_COUNT_FREQ] = '500';
+    process.env[envVariableKeys.THUNDRA_AGENT_METRIC_TIME_AWARE_SAMPLER_TIME_FREQ] = '10000';
+
+    const config = new MetricConfig(); 
+
+    it('Should get default samling value from environment variables',() => {
+        expect(config.enabled).toBe(true);
+        
+        expect(config.samplerConfig.countAwareSamplerConfig.enabled).toEqual(true);
+        expect(config.samplerConfig.countAwareSamplerConfig.countFreq).toEqual(500);
+
+        expect(config.samplerConfig.timeAwareSamplerConfig.enabled).toEqual(true);
+        expect(config.samplerConfig.timeAwareSamplerConfig.timeFreq).toEqual(10000);
+
+        process.env[envVariableKeys.THUNDRA_AGENT_METRIC_SAMPLER_COUNTAWARE_COUNTFREQ] = null;
+        process.env[envVariableKeys.THUNDRA_AGENT_METRIC_TIME_AWARE_SAMPLER_TIME_FREQ] =  null;
+    });
+});

--- a/test/plugins/metric.config.test.js
+++ b/test/plugins/metric.config.test.js
@@ -34,3 +34,14 @@ describe('default Metric Config', () => {
         process.env[envVariableKeys.THUNDRA_AGENT_METRIC_TIME_AWARE_SAMPLER_TIME_FREQ] =  null;
     });
 });
+
+describe('Metric with no sampler configured', () => {
+    const config = new MetricConfig(); 
+    config.samplerConfig.countAwareSampler = undefined;
+    config.samplerConfig.timeAwareSampler = undefined;
+    config.samplerConfig.customSampler = undefined;
+
+    it('Should true when is sampled called',() => {
+        expect(config.samplerConfig.isSampled()).toBe(true);
+    });
+});

--- a/test/plugins/trace.test.js
+++ b/test/plugins/trace.test.js
@@ -325,7 +325,7 @@ describe('Trace', () => {
 
         tracer.setPluginContext(pluginContext);
         const beforeInvocationData = createMockBeforeInvocationData();
-        beforeInvocationData.originalEvent = mockAWSEvents.createKinesisMockEvent();
+        beforeInvocationData.originalEvent = mockAWSEvents.createMockKinesisEvent();
         tracer.beforeInvocation(beforeInvocationData);
 
         it('should set trigger tags for Kinesis to root span', () => {
@@ -342,7 +342,7 @@ describe('Trace', () => {
 
         tracer.setPluginContext(pluginContext);
         const beforeInvocationData = createMockBeforeInvocationData();
-        beforeInvocationData.originalEvent = mockAWSEvents.createFirehoseMockEvent();
+        beforeInvocationData.originalEvent = mockAWSEvents.createMockFirehoseEvent();
         tracer.beforeInvocation(beforeInvocationData);
 
         it('should set trigger tags for FireHose to root span', () => {
@@ -359,7 +359,7 @@ describe('Trace', () => {
 
         tracer.setPluginContext(pluginContext);
         const beforeInvocationData = createMockBeforeInvocationData();
-        beforeInvocationData.originalEvent = mockAWSEvents.createDynamoDBMockEvent();
+        beforeInvocationData.originalEvent = mockAWSEvents.createMockDynamoDBEvent();
         tracer.beforeInvocation(beforeInvocationData);
 
         it('should set trigger tags for DynamoDB to root span', () => {
@@ -488,6 +488,24 @@ describe('Trace', () => {
             expect(tracer.rootSpan.tags['topology.vertex']).toBe(true);
         });
     });
+
+    describe('beforeInvocation with APIGatewayPassThrough event ', () => {
+        const tracer = Trace();
+        const pluginContext = createMockPluginContext();
+
+        tracer.setPluginContext(pluginContext);
+        const beforeInvocationData = createMockBeforeInvocationData();
+        beforeInvocationData.originalEvent = mockAWSEvents.createMockAPIGatewayPassThroughRequest();
+        tracer.beforeInvocation(beforeInvocationData);
+
+        it('should set trigger tags for APIGatewayProxy to root span', () => {
+            expect(tracer.rootSpan.tags['trigger.domainName']).toBe('API');
+            expect(tracer.rootSpan.tags['trigger.className']).toBe('AWS-APIGateway');
+            expect(tracer.rootSpan.tags['trigger.operationNames']).toEqual([ 'random.execute-api.us-west-2.amazonaws.com/dev/hello' ]);
+            expect(tracer.rootSpan.tags['topology.vertex']).toBe(true);
+        });
+    });
+
 
     describe('beforeInvocation with Lambda event', () => {
         const tracer = Trace();


### PR DESCRIPTION
Also fixes issues below :

- Make the count and time sampling enabled by default.  
- Add support for injecting trigger information when lambda is called API Gateway Passthrough Request.
- Remove extra space character at the end of the `aws.lambda.invocation.request_id` tags.