### PR TITLE
Programmatic config fix for `boolean` variables

### DIFF
--- a/src/plugins/config/ThundraConfig.ts
+++ b/src/plugins/config/ThundraConfig.ts
@@ -35,8 +35,9 @@ class ThundraConfig {
         this.xrayConfig = new AwsXRayConfig(options.xrayConfig);
         this.trustAllCert = koalas(Utils.getConfiguration(
             envVariableKeys.THUNDRA_AGENT_LAMBDA_TRUST_ALL_CERTIFICATES), options.trustAllCert, false);
-        this.warmupAware = koalas(Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_WARMUP_AWARE) === 'true',
-                                options.warmupAware, false);
+        this.warmupAware = Utils.getConfiguration(
+                envVariableKeys.THUNDRA_LAMBDA_WARMUP_AWARE) ? Utils.getConfiguration(
+                    envVariableKeys.THUNDRA_LAMBDA_WARMUP_AWARE) === 'true' : options.warmupAware;
     }
 
 }

--- a/src/plugins/config/TraceConfig.ts
+++ b/src/plugins/config/TraceConfig.ts
@@ -25,17 +25,20 @@ class TraceConfig extends BasePluginConfig {
     constructor(options: any) {
         options = options ? options : {};
         super(koalas(options.enabled, true));
-        this.disableRequest = koalas(Utils.getConfiguration(
-            envVariableKeys.THUNDRA_LAMBDA_TRACE_REQUEST_SKIP) === 'true', options.disableRequest, false);
-        this.disableResponse = koalas(Utils.getConfiguration(
-            envVariableKeys.THUNDRA_LAMBDA_TRACE_RESPONSE_SKIP) === 'true', options.disableResponse, false);
+        this.disableRequest = Utils.getConfiguration(
+            envVariableKeys.THUNDRA_LAMBDA_TRACE_REQUEST_SKIP) ? Utils.getConfiguration(
+                envVariableKeys.THUNDRA_LAMBDA_TRACE_REQUEST_SKIP) === 'true' : options.disableRequest;
+        this.disableResponse = Utils.getConfiguration(
+            envVariableKeys.THUNDRA_LAMBDA_TRACE_RESPONSE_SKIP) ? Utils.getConfiguration(
+                envVariableKeys.THUNDRA_LAMBDA_TRACE_RESPONSE_SKIP) === 'true' : options.disableResponse;
         this.maskRequest = koalas(options.maskRequest, null);
         this.maskResponse = koalas(options.maskResponse, null);
         this.disabledIntegrations = koalas([]);
         this.tracerConfig = koalas(options.tracerConfig, {});
         this.traceableConfigs = [];
-        this.disableInstrumentation = koalas(Utils.getConfiguration(
-            envVariableKeys.THUNDRA_LAMBDA_TRACE_INSTRUMENT_DISABLE) === 'true',  options.disableInstrumentation, true);
+        this.disableInstrumentation = Utils.getConfiguration(
+            envVariableKeys.THUNDRA_LAMBDA_TRACE_INSTRUMENT_DISABLE) ? Utils.getConfiguration(
+                envVariableKeys.THUNDRA_LAMBDA_TRACE_INSTRUMENT_DISABLE) === 'true' : options.disableInstrumentation;
         this.samplerConfig = new TraceSamplerConfig(options.samplerConfig);
 
         for (const key of Object.keys(process.env)) {

--- a/src/plugins/integrations/AWSIntegration.ts
+++ b/src/plugins/integrations/AWSIntegration.ts
@@ -78,6 +78,10 @@ class AWSIntegration implements Integration {
         try {
           const tracer = ThundraTracer.getInstance();
 
+          if (!tracer) {
+            return wrappedFunction.apply(this, [callback]);
+          }
+
           const request = this;
           const serviceEndpoint = request.service.config.endpoint;
           const serviceName = Utils.getServiceName(serviceEndpoint as string);

--- a/src/plugins/integrations/HttpIntegration.ts
+++ b/src/plugins/integrations/HttpIntegration.ts
@@ -53,6 +53,11 @@ class HttpIntegration implements Integration {
       return function requestWrapper(options: any, callback: any) {
         try {
           const tracer = ThundraTracer.getInstance();
+
+          if (!tracer) {
+            return request.apply(this, [options, callback]);
+          }
+
           const method = (options.method || 'GET').toUpperCase();
           options = typeof options === 'string' ? url.parse(options) : options;
           const host = options.hostname || options.host || 'localhost';

--- a/src/plugins/integrations/HttpIntegration.ts
+++ b/src/plugins/integrations/HttpIntegration.ts
@@ -20,8 +20,8 @@ class HttpIntegration implements Integration {
   basedir: string;
 
   constructor(config: any) {
-    this.hook = Hook('http', { internals: true }, (exp: any, name: string, basedir: string) => {
-      if (name === 'http') {
+    this.hook = Hook(['http', 'https'], { internals: true }, (exp: any, name: string, basedir: string) => {
+      if (name === 'http' || name === 'https') {
         this.lib = exp;
         this.config = config;
         this.basedir = basedir;

--- a/src/plugins/integrations/MySQL2Integration.ts
+++ b/src/plugins/integrations/MySQL2Integration.ts
@@ -47,6 +47,11 @@ class MySQL2Integration implements Integration {
       return function queryWrapper(sql: any, values: any, cb: any) {
         try {
           const tracer = ThundraTracer.getInstance();
+
+          if (!tracer) {
+            return query.call(this, sql, values, cb);
+          }
+
           const parentSpan = tracer.getActiveSpan();
 
           span = tracer._startSpan(this.config.database, {

--- a/src/plugins/integrations/PostgreIntegration.ts
+++ b/src/plugins/integrations/PostgreIntegration.ts
@@ -47,6 +47,10 @@ class PostgreIntegration implements Integration {
         let span: ThundraSpan;
         try {
           const tracer = ThundraTracer.getInstance();
+
+          if (!tracer) {
+            return query.apply(this, arguments);
+          }
           const parentSpan = tracer.getActiveSpan();
 
           const params = this.connectionParameters;

--- a/src/plugins/integrations/RedisIntegration.ts
+++ b/src/plugins/integrations/RedisIntegration.ts
@@ -47,6 +47,10 @@ class RedisIntegration implements Integration {
         try {
           const tracer = ThundraTracer.getInstance();
 
+          if (!tracer) {
+            return internalSendCommand.call(this, options);
+          }
+
           if (!options) {
             return internalSendCommand.call(this, options);
           }

--- a/test/plugins/thundra.config.test.js
+++ b/test/plugins/thundra.config.test.js
@@ -1,0 +1,45 @@
+import ThundraConfig from '../../dist/plugins/config/ThundraConfig';
+
+describe('Trace Config Test', () => {
+    it('with programmatic config',() => {
+        const config = new ThundraConfig({
+            warmupAware: true,
+            traceConfig: {
+                disableRequest: true,
+                disableResponse: true,
+                disableInstrumentation: true
+            }
+        });
+
+        expect(config.warmupAware).toEqual(true);
+        expect(config.traceConfig.disableRequest).toEqual(true);
+        expect(config.traceConfig.disableResponse).toEqual(true);
+        expect(config.traceConfig.disableInstrumentation).toEqual(true);
+    });
+
+    it('with environment variable overrides programmatic',() => {
+        process.env.thundra_agent_lambda_trace_request_skip = 'false';
+        process.env.thundra_agent_lambda_trace_response_skip = 'false';
+        process.env.thundra_agent_lambda_trace_instrument_disable = 'false';
+        process.env.thundra_lambda_warmup_warmupAware = 'false';
+
+        const config = new ThundraConfig({
+            warmupAware: true,
+            traceConfig: {
+                disableRequest: true,
+                disableResponse: true,
+                disableInstrumentation: true
+            }
+        });
+
+        expect(config.traceConfig.disableRequest).toEqual(false);
+        expect(config.traceConfig.disableResponse).toEqual(false);
+        expect(config.traceConfig.disableInstrumentation).toEqual(false);
+
+        process.env.thundra_agent_lambda_trace_request_skip = undefined;
+        process.env.thundra_agent_lambda_trace_response_skip = undefined;
+        process.env.thundra_agent_lambda_trace_instrument_disable = undefined;
+        process.env.thundra_lambda_warmup_warmupAware = undefined;
+    });
+});
+

--- a/test/plugins/thundra.config.test.js
+++ b/test/plugins/thundra.config.test.js
@@ -17,7 +17,7 @@ describe('Trace Config Test', () => {
         expect(config.traceConfig.disableInstrumentation).toEqual(true);
     });
 
-    it('with environment variable overrides programmatic',() => {
+    it('with environment variable overrides programmatic with false value',() => {
         process.env.thundra_agent_lambda_trace_request_skip = 'false';
         process.env.thundra_agent_lambda_trace_response_skip = 'false';
         process.env.thundra_agent_lambda_trace_instrument_disable = 'false';
@@ -31,10 +31,36 @@ describe('Trace Config Test', () => {
                 disableInstrumentation: true
             }
         });
-
+        expect(config.warmupAware).toEqual(false);
         expect(config.traceConfig.disableRequest).toEqual(false);
         expect(config.traceConfig.disableResponse).toEqual(false);
         expect(config.traceConfig.disableInstrumentation).toEqual(false);
+
+        process.env.thundra_agent_lambda_trace_request_skip = undefined;
+        process.env.thundra_agent_lambda_trace_response_skip = undefined;
+        process.env.thundra_agent_lambda_trace_instrument_disable = undefined;
+        process.env.thundra_lambda_warmup_warmupAware = undefined;
+    });
+
+    it('with environment variable overrides programmatic with true value',() => {
+        process.env.thundra_agent_lambda_trace_request_skip = 'true';
+        process.env.thundra_agent_lambda_trace_response_skip = 'true';
+        process.env.thundra_agent_lambda_trace_instrument_disable = 'true';
+        process.env.thundra_lambda_warmup_warmupAware = 'true';
+
+        const config = new ThundraConfig({
+            warmupAware: false,
+            traceConfig: {
+                disableRequest: false,
+                disableResponse: false,
+                disableInstrumentation: false
+            }
+        });
+        
+        expect(config.warmupAware).toEqual(true);
+        expect(config.traceConfig.disableRequest).toEqual(true);
+        expect(config.traceConfig.disableResponse).toEqual(true);
+        expect(config.traceConfig.disableInstrumentation).toEqual(true);
 
         process.env.thundra_agent_lambda_trace_request_skip = undefined;
         process.env.thundra_agent_lambda_trace_response_skip = undefined;


### PR DESCRIPTION
Also skip instrumentation if `tracer` is undefined in integrations.