### PR TITLE
Implement Chaos Injecting Listener and new Integrations

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,6 @@
   "moduleFileExtensions": ["js"],
   "collectCoverageFrom": ["dist/*.js", "dist/opentracing/*.js", "dist/opentracing/instrument/*.js", "dist/opentracing/sampler/*.js", "dist/plugins/*.js", 
     "dist/plugins/data/base/*.js", "dist/plugins/data/invocation/*.js", "dist/plugins/data/metric/*.js",
-    "dist/plugins/config/*.js", "dist/plugins/data/trace/*.js", "dist/plugins/error/*.js", "dist/plugins/integrations/*.js",
+    "dist/plugins/config/*.js", "dist/plugins/data/trace/*.js", "dist/plugins/error/*.js",
     "dist/plugins/listeners/*.js", "dist/plugins/support/*.js", "index.js"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,10 @@ services:
     image: redis:4.0-alpine
     ports:
       - "127.0.0.1:6379:6379"
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms64m -Xmx64m"
+    ports:
+      - "127.0.0.1:9200:9200"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thundra/core",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -582,6 +582,15 @@
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
+      }
+    },
+    "agentkeepalive": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "dev": true,
+      "requires": {
+        "humanize-ms": "^1.2.1"
       }
     },
     "ajv": {
@@ -2216,6 +2225,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
       "dev": true
     },
     "binary-extensions": {
@@ -4530,6 +4545,25 @@
         "jsbn": "~0.1.0"
       }
     },
+    "elasticsearch": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.4.1.tgz",
+      "integrity": "sha512-IL46Sv9krCKtpvlI37/vQVQrWx6QeT1OJhfWW6L3fIXzR1Vv5utO+DHYz8AosUI6vlkxShoq+y6sUIBhTF1OIg==",
+      "dev": true,
+      "requires": {
+        "agentkeepalive": "^3.4.1",
+        "chalk": "^1.0.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.37",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.37.tgz",
@@ -6682,6 +6716,15 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "i": {
@@ -9200,6 +9243,50 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mysql": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.16.0.tgz",
+      "integrity": "sha512-dPbN2LHonQp7D5ja5DJXNbCLe/HRdu+f3v61aguzNRQIrmZLOeRoymBYyeThrR6ug+FqzDL95Gc9maqZUJS+Gw==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "4.1.0",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "mysql2": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,14 @@
     "babel-preset-stage-0": "^6.24.1",
     "babel-runtime": "^6.26.0",
     "coveralls": "^3.0.1",
+    "elasticsearch": "^15.4.1",
     "eslint": "^4.19.1",
     "eslint-plugin-babel": "^5.1.0",
     "gaze-run-interrupt": "^1.0.1",
     "i": "^0.3.6",
     "jest": "^22.4.4",
+    "mysql": "^2.16.0",
+    "mysql2": "1.6.1",
     "npm-run-all": "^4.1.1",
     "opentracing": "0.14.1",
     "pg": "6.4.0",
@@ -73,8 +76,7 @@
     "typescript": "^2.9.2",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.14.0",
-    "webpack-cli": "^3.0.8",
-    "mysql2": "1.6.1"
+    "webpack-cli": "^3.0.8"
   },
   "dependencies": {
     "@thundra/warmup": "1.0.0",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -2,8 +2,13 @@ import * as url from 'url';
 import HttpIntegration from './plugins/integrations/HttpIntegration';
 import PostgreIntegration from './plugins/integrations/PostgreIntegration';
 import MySQL2Integration from './plugins/integrations/MySQL2Integration';
+import MySQLIntegration from './plugins/integrations/MySQLIntegration';
 import RedisIntegration from './plugins/integrations/RedisIntegration';
 import AWSIntegration from './plugins/integrations/AWSIntegration';
+import ESIntegration from './plugins/integrations/ESIntegration';
+import FilteringSpanListener from './plugins/listeners/FilteringSpanListener';
+import ErrorInjectorSpanListener from './plugins/listeners/ErrorInjectorSpanListener';
+import LatencyInjectorSpanListener from './plugins/listeners/LatencyInjectorSpanListener';
 
 export const envVariableKeys = {
     THUNDRA_LAMBDA_WARMUP_AWARE: 'thundra_lambda_warmup_warmupAware',
@@ -47,6 +52,9 @@ export const envVariableKeys = {
     THUNDRA_APPLICATION_TAG_PROP_NAME_PREFIX: 'thundra_agent_lambda_application_tag_',
     THUNDRA_APPLICATION_ID: 'thundra_agent_lambda_application_id',
     THUNDRA_APPLICATION_NAME: 'thundra_agent_lambda_application_name',
+    THUNDRA_AGENT_LAMBDA_SPAN_LISTENER_DEF : 'thundra_agent_lambda_trace_span_listener',
+
+    THUNDRA_AGENT_LAMBDA_SAMPLE_TIMED_OUT_INVOCATIONS: 'thundra_agent_lambda_sample_timed_out_invocations',
 
 };
 
@@ -180,6 +188,7 @@ export const DBTypes = {
     REDIS: 'redis',
     PG: 'postgresql',
     MYSQL: 'mysql',
+    ELASTICSEARCH: 'elasticsearch',
 };
 
 export const HttpTags = {
@@ -198,6 +207,13 @@ export const RedisTags = {
     REDIS_COMMANDS: 'redis.commands',
     REDIS_COMMAND_TYPE: 'redis.command.type',
     REDIS_COMMAND_ARGS: 'redis.command.args',
+};
+
+export const ESTags = {
+    ES_URL: 'elasticsearch.url',
+    ES_METHOD: 'elasticsearch.method',
+    ES_PARAMS: 'elasticsearch.params',
+    ES_BODY: 'elasticsearch.body',
 };
 
 export const AwsSDKTags = {
@@ -250,6 +266,7 @@ export const SpanTags = {
 
 export const SpanTypes = {
     REDIS: 'Redis',
+    ELASTIC: 'Elastic',
     RDB: 'RDB',
     HTTP: 'HTTP',
     AWS_DYNAMO: 'AWS-DynamoDB',
@@ -265,8 +282,16 @@ export const INTEGRATIONS: any = {
     http: HttpIntegration,
     pg: PostgreIntegration,
     mysql2: MySQL2Integration,
+    mysql: MySQLIntegration,
     redis: RedisIntegration,
     aws: AWSIntegration,
+    es: ESIntegration,
+};
+
+export const LISTENERS: any = {
+    FilteringSpanListener,
+    ErrorInjectorSpanListener,
+    LatencyInjectorSpanListener,
 };
 
 export const SQSRequestTypes: any = {

--- a/src/ThundraWrapper.ts
+++ b/src/ThundraWrapper.ts
@@ -158,7 +158,6 @@ class ThundraWrapper {
             if (this.config.sampleTimedOutInvocations) {
                 if (error instanceof TimeoutError) {
                     this.executeAfteInvocationAndReport(afterInvocationData);
-                    this.executeAfteInvocationAndReport(afterInvocationData);
                 }
             } else {
                 this.executeAfteInvocationAndReport(afterInvocationData);

--- a/src/ThundraWrapper.ts
+++ b/src/ThundraWrapper.ts
@@ -158,6 +158,12 @@ class ThundraWrapper {
             if (this.config.sampleTimedOutInvocations) {
                 if (error instanceof TimeoutError) {
                     this.executeAfteInvocationAndReport(afterInvocationData);
+                } else {
+                    this.plugins.map((plugin: any) => {
+                        if (plugin.destroy && typeof (plugin.destroy) === 'function') {
+                            plugin.destroy();
+                        }
+                    });
                 }
             } else {
                 this.executeAfteInvocationAndReport(afterInvocationData);

--- a/src/ThundraWrapper.ts
+++ b/src/ThundraWrapper.ts
@@ -21,6 +21,7 @@ import TimeoutError from './plugins/error/TimeoutError';
 import HttpError from './plugins/error/HttpError';
 import Utils from './plugins/utils/Utils';
 import { envVariableKeys } from './Constants';
+import ThundraConfig from './plugins/config/ThundraConfig';
 
 class ThundraWrapper {
 
@@ -29,6 +30,7 @@ class ThundraWrapper {
     private originalContext: any;
     private originalCallback: any;
     private originalFunction: any;
+    private config: ThundraConfig;
     private plugins: any;
     private pluginContext: any;
     private reported: boolean;
@@ -43,6 +45,7 @@ class ThundraWrapper {
         this.originalContext = context;
         this.originalCallback = callback;
         this.originalFunction = originalFunction;
+        this.config = pluginContext.config ? pluginContext.config : {};
         this.plugins = plugins;
         this.pluginContext = pluginContext;
         this.pluginContext.maxMemory = parseInt(context.memoryLimitInMB, 10);
@@ -100,19 +103,11 @@ class ThundraWrapper {
                         this.wrappedContext,
                         this.wrappedCallback,
                     );
-                    if (result instanceof Promise) {
-                        result.then(
-                            (data) => {
-                                this.report(null, data, () => {
-                                    this.invokeCallback(null, data);
-                                });
-                            },
-                            (err) => {
-                                this.report(err, null, () => {
-                                    this.invokeCallback(err, null);
-                                });
-                            });
+
+                    if (result && result.then !== undefined && typeof result.then === 'function') {
+                        result.then(this.wrappedContext.succeed, this.wrappedContext.fail);
                     }
+
                     return result;
                 } catch (error) {
                     this.report(error, null, null);
@@ -137,6 +132,13 @@ class ThundraWrapper {
         );
     }
 
+    async executeAfteInvocationAndReport(afterInvocationData: any) {
+        await this.executeHook('after-invocation', afterInvocationData, true);
+        if (Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_REPORT_CLOUDWATCH_ENABLE) !== 'true') {
+            await this.reporter.sendReports();
+        }
+    }
+
     async report(error: any, result: any, callback: any) {
         if (!this.reported) {
             this.reported = true;
@@ -153,9 +155,13 @@ class ThundraWrapper {
                 };
             }
 
-            await this.executeHook('after-invocation', afterInvocationData, true);
-            if (Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_REPORT_CLOUDWATCH_ENABLE) !== 'true') {
-                await this.reporter.sendReports();
+            if (this.config.sampleTimedOutInvocations) {
+                if (error instanceof TimeoutError) {
+                    this.executeAfteInvocationAndReport(afterInvocationData);
+                    this.executeAfteInvocationAndReport(afterInvocationData);
+                }
+            } else {
+                this.executeAfteInvocationAndReport(afterInvocationData);
             }
 
             if (this.timeout) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,11 @@ import Log from './plugins/Log';
 import AwsXRayConfig from './plugins/config/AwsXRayConfig';
 import InvocationSupport from './plugins/support/InvocationSupport';
 import ApplicationSupport from './plugins/support/ApplicationSupport';
+import ErrorInjectorSpanListener from './plugins/listeners/ErrorInjectorSpanListener';
+import FilteringSpanListener from './plugins/listeners/FilteringSpanListener';
+import LatencyInjectorSpanListener from './plugins/listeners/LatencyInjectorSpanListener';
+import SpanFilter from './plugins/listeners/SpanFilter';
+import StandardSpanFilterer from './plugins/listeners/StandardSpanFilterer';
 
 const ThundraWarmup = require('@thundra/warmup');
 
@@ -81,6 +86,7 @@ module.exports = (options: any) => {
         apiKey: config.apiKey,
         timeoutMargin: config.timeoutMargin,
         transactionId: null,
+        config,
     };
 
     config.plugins.forEach((plugin: any) => {
@@ -150,3 +156,11 @@ module.exports.config = {
 };
 
 module.exports.InvocationSupport = InvocationSupport;
+
+module.exports.listeners = {
+    ErrorInjectorSpanListener,
+    FilteringSpanListener,
+    LatencyInjectorSpanListener,
+    SpanFilter,
+    StandardSpanFilterer,
+};

--- a/src/opentracing/Recorder.ts
+++ b/src/opentracing/Recorder.ts
@@ -32,7 +32,9 @@ class ThundraRecorder {
             let shouldInvokeCallback = true;
             for (const listener of this.listeners) {
                 const isCallbackCalled = listener.onSpanStarted(span, options.me, options.callback, options.args);
-                shouldInvokeCallback = !isCallbackCalled;
+                if (shouldInvokeCallback) {
+                    shouldInvokeCallback = !isCallbackCalled;
+                }
             }
             if (shouldInvokeCallback) {
                 if (typeof(options.callback) === 'function') {
@@ -48,7 +50,9 @@ class ThundraRecorder {
             let shouldInvokeCallback = true;
             for (const listener of this.listeners) {
                 const isCallbackCalled = listener.onSpanFinished(span, options.me, options.callback, options.args);
-                shouldInvokeCallback = !isCallbackCalled;
+                if (shouldInvokeCallback) {
+                    shouldInvokeCallback = !isCallbackCalled;
+                }
             }
             if (shouldInvokeCallback) {
                 if (typeof(options.callback) === 'function') {

--- a/src/opentracing/Recorder.ts
+++ b/src/opentracing/Recorder.ts
@@ -7,35 +7,52 @@ class ThundraRecorder {
     private activeSpanStack: Stack<ThundraSpan>;
     private spanList: ThundraSpan[];
     private spanOrder = 1;
-    private listeners: ThundraSpanListener[];
+    private listeners: ThundraSpanListener[] = [];
 
     constructor() {
         this.activeSpanStack = new Stack<ThundraSpan>();
         this.spanList = [];
-        this.listeners = [];
     }
 
     record(span: ThundraSpan, spanEvent: SpanEvent, options?: any): void {
+        options = options ? options : {};
         if (!span) {
             ThundraLogger.getInstance().error('Undefined span.');
-        } else {
-            if (spanEvent === SpanEvent.SPAN_START) {
-                ThundraLogger.getInstance().debug(`Span with name ${span.operationName} started.`);
-                if (!(options && options.disableActiveSpanHandling === true)) {
-                    this.activeSpanStack.push(span);
+            return;
+        }
+
+        if (spanEvent === SpanEvent.SPAN_START) {
+            ThundraLogger.getInstance().debug(`Span with name ${span.operationName} started.`);
+            if (!(options && options.disableActiveSpanHandling === true)) {
+                this.activeSpanStack.push(span);
+            }
+            span.order = this.spanOrder++;
+            this.spanList.push(span);
+
+            let shouldInvokeCallback = true;
+            for (const listener of this.listeners) {
+                const isCallbackCalled = listener.onSpanStarted(span, options.me, options.callback, options.args);
+                shouldInvokeCallback = !isCallbackCalled;
+            }
+            if (shouldInvokeCallback) {
+                if (typeof(options.callback) === 'function') {
+                    options.callback.apply(options.me, options.args);
                 }
-                span.order = this.spanOrder++;
-                for (const listener of this.listeners) {
-                    listener.onSpanStarted(span);
-                }
-            } else if (spanEvent === SpanEvent.SPAN_FINISH) {
-                ThundraLogger.getInstance().debug(`Span with name ${span.operationName} finished.`);
-                if (!(options && options.disableActiveSpanHandling === true)) {
-                    this.activeSpanStack.pop();
-                }
-                this.spanList.push(span);
-                for (const listener of this.listeners) {
-                    listener.onSpanFinished(span);
+            }
+        } else if (spanEvent === SpanEvent.SPAN_FINISH) {
+            ThundraLogger.getInstance().debug(`Span with name ${span.operationName} finished.`);
+            if (!(options && options.disableActiveSpanHandling === true)) {
+                this.activeSpanStack.pop();
+            }
+
+            let shouldInvokeCallback = true;
+            for (const listener of this.listeners) {
+                const isCallbackCalled = listener.onSpanFinished(span, options.me, options.callback, options.args);
+                shouldInvokeCallback = !isCallbackCalled;
+            }
+            if (shouldInvokeCallback) {
+                if (typeof(options.callback) === 'function') {
+                    options.callback.apply(options.me, options.args);
                 }
             }
         }
@@ -57,14 +74,15 @@ class ThundraRecorder {
         return this.activeSpanStack.pop();
     }
 
-    addListener(listener: ThundraSpanListener): void {
-        this.listeners.push(listener);
-    }
-
     destroy() {
         this.activeSpanStack.clear();
         this.spanList = [];
         this.spanOrder = 1;
+        this.listeners = [];
+    }
+
+    addSpanListener(listener: ThundraSpanListener) {
+        this.listeners.push(listener);
     }
 }
 

--- a/src/opentracing/Recorder.ts
+++ b/src/opentracing/Recorder.ts
@@ -21,6 +21,8 @@ class ThundraRecorder {
             return;
         }
 
+        let shouldInvokeCallback = true;
+
         if (spanEvent === SpanEvent.SPAN_START) {
             ThundraLogger.getInstance().debug(`Span with name ${span.operationName} started.`);
             if (!(options && options.disableActiveSpanHandling === true)) {
@@ -29,9 +31,9 @@ class ThundraRecorder {
             span.order = this.spanOrder++;
             this.spanList.push(span);
 
-            let shouldInvokeCallback = true;
             for (const listener of this.listeners) {
-                const isCallbackCalled = listener.onSpanStarted(span, options.me, options.callback, options.args);
+                const isCallbackCalled = listener.onSpanStarted(span, options.me,
+                    options.callback, options.args, !shouldInvokeCallback);
                 if (shouldInvokeCallback) {
                     shouldInvokeCallback = !isCallbackCalled;
                 }
@@ -47,9 +49,9 @@ class ThundraRecorder {
                 this.activeSpanStack.pop();
             }
 
-            let shouldInvokeCallback = true;
             for (const listener of this.listeners) {
-                const isCallbackCalled = listener.onSpanFinished(span, options.me, options.callback, options.args);
+                const isCallbackCalled = listener.onSpanStarted(span, options.me,
+                    options.callback, options.args, !shouldInvokeCallback);
                 if (shouldInvokeCallback) {
                     shouldInvokeCallback = !isCallbackCalled;
                 }

--- a/src/opentracing/Span.ts
+++ b/src/opentracing/Span.ts
@@ -130,7 +130,7 @@ class ThundraSpan extends Span {
 
     this.finishTime = finishTime;
     if (this.spanContext.sampled) {
-      this.parentTracer._record(this);
+      this.parentTracer._record(this, {disableActiveSpanHandling: false});
     }
   }
 
@@ -143,6 +143,18 @@ class ThundraSpan extends Span {
     this.finishTime = finishTime;
     if (this.spanContext.sampled) {
       this.parentTracer._record(this, {disableActiveSpanHandling: true});
+    }
+  }
+
+  closeWithCallback(me: any, callback: () => any, args: any[] , finishTime: number = Date.now()) {
+    if (this.finishTime !== 0) {
+      ThundraLogger.getInstance().debug('Span is already closed.');
+      return;
+    }
+
+    this.finishTime = finishTime;
+    if (this.spanContext.sampled) {
+      this.parentTracer._record(this, {disableActiveSpanHandling: true, me, callback, args});
     }
   }
 

--- a/src/plugins/AwsXRay.ts
+++ b/src/plugins/AwsXRay.ts
@@ -1,8 +1,8 @@
 import PluginContext from './PluginContext';
 import AwsXRayConfig from './config/AwsXRayConfig';
 import ThundraTracer from '../opentracing/Tracer';
-import AwsXRayThundraSpanListener from './listeners/AwsXRayThundraSpanListener';
 import ThundraLogger from '../ThundraLogger';
+import AwsXRayThundraSpanListener from './listeners/AwsXRayThundraSpanListener';
 
 class AwsXRay {
     hooks: { 'before-invocation': (data: any) => void; 'after-invocation': (data: any) => void; };

--- a/src/plugins/Invocation.ts
+++ b/src/plugins/Invocation.ts
@@ -37,6 +37,7 @@ class Invocation {
     }
 
     beforeInvocation = (data: any) => {
+        this.destroy();
         const { originalContext, reporter } = data;
         this.reporter = reporter;
         this.finishTimestamp = null;

--- a/src/plugins/Invocation.ts
+++ b/src/plugins/Invocation.ts
@@ -37,7 +37,6 @@ class Invocation {
     }
 
     beforeInvocation = (data: any) => {
-        InvocationSupport.removeTags();
         const { originalContext, reporter } = data;
         this.reporter = reporter;
         this.finishTimestamp = null;
@@ -107,6 +106,10 @@ class Invocation {
         this.invocationData.duration = this.finishTimestamp - this.startTimestamp;
         const reportData = Utils.generateReport(this.invocationData, this.apiKey);
         this.report(reportData);
+        this.destroy();
+    }
+
+    destroy(): void {
         InvocationSupport.removeTags();
     }
 }

--- a/src/plugins/Log.ts
+++ b/src/plugins/Log.ts
@@ -95,9 +95,7 @@ class Log {
             this.report(logReportData);
         }
 
-        if (Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_LOG_CONSOLE_DISABLE) !== 'true') {
-            this.unShimConsole();
-        }
+        this.destroy();
     }
 
     reportLog(logInfo: any): void {
@@ -146,6 +144,12 @@ class Log {
                 Object.defineProperty(console, method, descriptor);
             }
         });
+    }
+
+    destroy(): void {
+        if (Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_LOG_CONSOLE_DISABLE) !== 'true') {
+            this.unShimConsole();
+        }
     }
 }
 

--- a/src/plugins/PluginContext.ts
+++ b/src/plugins/PluginContext.ts
@@ -1,3 +1,5 @@
+import ThundraConfig from './config/ThundraConfig';
+
 class PluginContext {
     applicationId: string;
     applicationRegion: string;
@@ -11,6 +13,7 @@ class PluginContext {
     transactionId?: string;
     error?: Error;
     maxMemory?: number;
+    config: ThundraConfig;
 }
 
 export default PluginContext;

--- a/src/plugins/Trace.ts
+++ b/src/plugins/Trace.ts
@@ -66,7 +66,8 @@ export class Trace {
     }
 
     beforeInvocation = (data: any) => {
-        this.tracer.destroy();
+        this.destroy();
+
         const { originalContext, originalEvent, reporter } = data;
 
         // awsRequestId can be `id` or undefined in local lambda environments, so we generate a unique id here.
@@ -197,12 +198,7 @@ export class Trace {
             }
         }
 
-        if (this.config && !(this.config.disableInstrumentation)) {
-            this.tracer.destroy();
-            if (typeof this.config.unhookModuleCompile === 'function') {
-                this.config.unhookModuleCompile();
-            }
-        }
+        this.destroy();
     }
 
     buildSpanData(span: ThundraSpan, pluginContext: PluginContext): SpanData {
@@ -225,6 +221,15 @@ export class Trace {
         spanData.logs = span.logs;
 
         return spanData;
+    }
+
+    destroy(): void {
+        if (this.config && !(this.config.disableInstrumentation)) {
+            this.tracer.destroy();
+            if (typeof this.config.unhookModuleCompile === 'function') {
+                this.config.unhookModuleCompile();
+            }
+        }
     }
 
     private getRequest(originalEvent: any): any {

--- a/src/plugins/config/ThundraConfig.ts
+++ b/src/plugins/config/ThundraConfig.ts
@@ -19,13 +19,16 @@ class ThundraConfig {
     logConfig: LogConfig;
     xrayConfig: AwsXRayConfig;
     timeoutMargin: number;
+    sampleTimedOutInvocations: boolean;
     plugins: any[];
 
     constructor(options: any) {
         options = options ? options : {};
         this.plugins = koalas(options.plugins, []);
         this.apiKey = koalas(Utils.getConfiguration(envVariableKeys.THUNDRA_APIKEY), options.apiKey, null);
-        this.disableThundra = koalas(Utils.getConfiguration(envVariableKeys.THUNDRA_DISABLE), options.disableThundra, false);
+        this.disableThundra = Utils.getConfiguration(
+            envVariableKeys.THUNDRA_DISABLE) ? Utils.getConfiguration(
+                envVariableKeys.THUNDRA_DISABLE) === 'true' : options.disableThundra;
         this.timeoutMargin = koalas(parseInt(Utils.getConfiguration(envVariableKeys.THUNDRA_LAMBDA_TIMEOUT_MARGIN), 10),
             options.timeoutMargin, TIMEOUT_MARGIN);
         this.traceConfig = new TraceConfig(options.traceConfig);
@@ -33,11 +36,21 @@ class ThundraConfig {
         this.logConfig = new LogConfig(options.logConfig);
         this.invocationConfig = new InvocationConfig(options.invocationConfig);
         this.xrayConfig = new AwsXRayConfig(options.xrayConfig);
+
         this.trustAllCert = koalas(Utils.getConfiguration(
             envVariableKeys.THUNDRA_AGENT_LAMBDA_TRUST_ALL_CERTIFICATES), options.trustAllCert, false);
+
+        this.trustAllCert = Utils.getConfiguration(
+                envVariableKeys.THUNDRA_AGENT_LAMBDA_TRUST_ALL_CERTIFICATES) ? Utils.getConfiguration(
+                    envVariableKeys.THUNDRA_AGENT_LAMBDA_TRUST_ALL_CERTIFICATES) === 'true' : options.trustAllCert;
+
         this.warmupAware = Utils.getConfiguration(
                 envVariableKeys.THUNDRA_LAMBDA_WARMUP_AWARE) ? Utils.getConfiguration(
                     envVariableKeys.THUNDRA_LAMBDA_WARMUP_AWARE) === 'true' : options.warmupAware;
+
+        this.sampleTimedOutInvocations = Utils.getConfiguration(
+            envVariableKeys.THUNDRA_AGENT_LAMBDA_SAMPLE_TIMED_OUT_INVOCATIONS) ? Utils.getConfiguration(
+                envVariableKeys.THUNDRA_AGENT_LAMBDA_SAMPLE_TIMED_OUT_INVOCATIONS) === 'true' : options.sampleTimedOutInvocations;
     }
 
 }

--- a/src/plugins/integrations/MySQLIntegration.ts
+++ b/src/plugins/integrations/MySQLIntegration.ts
@@ -12,7 +12,7 @@ import InvocationSupport from '../support/InvocationSupport';
 const shimmer = require('shimmer');
 const Hook = require('require-in-the-middle');
 
-class MySQL2Integration implements Integration {
+class MySQLIntegration implements Integration {
   config: any;
   lib: any;
   version: string;
@@ -20,13 +20,13 @@ class MySQL2Integration implements Integration {
   basedir: string;
 
   constructor(config: any) {
-    this.version = '^1.5';
-    this.hook = Hook('mysql2', { internals: true }, (exp: any, name: string, basedir: string) => {
-      if (name === 'mysql2/lib/connection.js') {
+    this.version = '>=2';
+    this.hook = Hook('mysql', { internals: true }, (exp: any, name: string, basedir: string) => {
+      if (name === 'mysql/lib/Connection.js' || name === 'lib/Connection.js') {
         const moduleValidator = new ModuleVersionValidator();
         const isValidVersion = moduleValidator.validateModuleVersion(basedir, this.version);
         if (!isValidVersion) {
-          ThundraLogger.getInstance().error(`Invalid module version for mysql2 integration.
+          ThundraLogger.getInstance().error(`Invalid module version for mysql integration.
                                              Supported version is ${this.version}`);
         } else {
           this.lib = exp;
@@ -128,4 +128,4 @@ class MySQL2Integration implements Integration {
   }
 }
 
-export default MySQL2Integration;
+export default MySQLIntegration;

--- a/src/plugins/integrations/RedisIntegration.ts
+++ b/src/plugins/integrations/RedisIntegration.ts
@@ -4,11 +4,11 @@ import {
   SpanTags, RedisTags, RedisCommandTypes, SpanTypes, DomainNames,
   ClassNames, DBTypes, DBTags, LAMBDA_APPLICATION_DOMAIN_NAME, LAMBDA_APPLICATION_CLASS_NAME,
 } from '../../Constants';
-import Utils from '../utils/Utils';
 import { DB_TYPE, DB_INSTANCE } from 'opentracing/lib/ext/tags';
 import ModuleVersionValidator from './ModuleVersionValidator';
 import ThundraLogger from '../../ThundraLogger';
 import ThundraSpan from '../../opentracing/Span';
+import InvocationSupport from '../support/InvocationSupport';
 
 const shimmer = require('shimmer');
 const Hook = require('require-in-the-middle');
@@ -55,6 +55,10 @@ class RedisIntegration implements Integration {
             return internalSendCommand.call(this, options);
           }
 
+          const me = this;
+
+          const functionName = InvocationSupport.getFunctionName();
+
           const parentSpan = tracer.getActiveSpan();
           let host = 'localhost';
           let port = '6379';
@@ -87,7 +91,7 @@ class RedisIntegration implements Integration {
               [SpanTags.TOPOLOGY_VERTEX]: true,
               [SpanTags.TRIGGER_DOMAIN_NAME]: LAMBDA_APPLICATION_DOMAIN_NAME,
               [SpanTags.TRIGGER_CLASS_NAME]: LAMBDA_APPLICATION_CLASS_NAME,
-              [SpanTags.TRIGGER_OPERATION_NAMES]: [tracer.functionName],
+              [SpanTags.TRIGGER_OPERATION_NAMES]: [functionName],
             },
           });
 
@@ -95,15 +99,10 @@ class RedisIntegration implements Integration {
 
           const wrappedCallback = (err: any, res: any) => {
             if (err) {
-              const parseError = Utils.parseError(err);
-              span.setTag('error', true);
-              span.setTag('error.kind', parseError.errorType);
-              span.setTag('error.message', parseError.errorMessage);
+              span.setErrorTag(err);
             }
 
-            span.close();
-
-            originalCallback(err, res);
+            span.closeWithCallback(me, originalCallback, [err, res]);
           };
 
           options.callback = wrappedCallback;

--- a/src/plugins/listeners/AwsXRayThundraSpanListener.ts
+++ b/src/plugins/listeners/AwsXRayThundraSpanListener.ts
@@ -20,7 +20,7 @@ class AwsXRayThundraSpanListener  implements ThundraSpanListener {
         this.subsegmentMap = new Map<string, any>();
     }
 
-    onSpanStarted(span: ThundraSpan): void {
+    onSpanStarted(span: ThundraSpan): boolean {
         try {
             if (!AWSXRay) {
                 ThundraLogger.getInstance().error('XRay plugin is enabled but cannot load module aws-xray-sdk-core.');
@@ -36,9 +36,11 @@ class AwsXRayThundraSpanListener  implements ThundraSpanListener {
         } catch (err) {
             ThundraLogger.getInstance().error('Error occurred while beginning XRay sub-segment for span ' + err);
         }
+
+        return false;
     }
 
-    onSpanFinished(span: ThundraSpan): void {
+    onSpanFinished(span: ThundraSpan): boolean {
         try {
             if (!AWSXRay) {
                 ThundraLogger.getInstance().error('XRay plugin is enabled but cannot load module aws-xray-sdk-core.');
@@ -57,6 +59,11 @@ class AwsXRayThundraSpanListener  implements ThundraSpanListener {
         } catch (err) {
             ThundraLogger.getInstance().error('Error occurred while ending XRay sub-segment for span ' + err);
         }
+        return false;
+    }
+
+    failOnError(): boolean {
+        return false;
     }
 
     onDestroy(): void {

--- a/src/plugins/listeners/ErrorInjectorSpanListener.ts
+++ b/src/plugins/listeners/ErrorInjectorSpanListener.ts
@@ -1,0 +1,82 @@
+import ThundraSpanListener from './ThundraSpanListener';
+import ThundraSpan from '../../opentracing/Span';
+
+const koalas = require('koalas');
+
+class ErrorInjectorSpanListener implements ThundraSpanListener {
+    private readonly DEFAULT_ERROR_MESSAGE: string = 'Error injected by Thundra!';
+    private readonly DEFAULT_INJECT_COUNT_FREQ: number = 1;
+    private readonly DEFAULT_INJECT_ON_FINISH: boolean = false;
+    private readonly DEFAULT_ERROR_TYPE: string = 'Error';
+
+    private injectCountFreq: number;
+    private counter: number;
+    private injectOnFinish: boolean;
+    private errorType: string;
+    private errorMessage: string;
+
+    constructor(opt: any = {}) {
+        this.injectCountFreq = JSON.parse(koalas(opt.injectCountFreq, this.DEFAULT_INJECT_COUNT_FREQ));
+        this.injectOnFinish = JSON.parse(koalas(opt.injectOnFinish, this.DEFAULT_INJECT_ON_FINISH));
+        this.errorType = koalas(opt.errorType, this.DEFAULT_ERROR_TYPE);
+        this.errorMessage = koalas(opt.errorMessage, this.DEFAULT_ERROR_MESSAGE);
+        this.errorMessage = this.errorMessage.replace(new RegExp('\"', 'g'), '');
+        this.errorType = this.errorType.replace(new RegExp('\"', 'g'), '');
+        this.counter = 0;
+    }
+
+    onSpanStarted(span: ThundraSpan, me: any, callback: () => any, args: any[]): boolean {
+        if (callback && !this.injectOnFinish) {
+            this._injectErrorWithCallback(span, me, callback);
+            return true;
+        }
+
+        if (!callback && !this.injectOnFinish && this.failOnError()) {
+            this._injectError(span, me);
+            return false;
+        }
+    }
+
+    onSpanFinished(span: ThundraSpan, me: any, callback: () => any, args: any[]): boolean {
+        if (callback && this.injectOnFinish) {
+            this._injectErrorWithCallback(span, me, callback);
+            return true;
+        }
+
+        if (!callback && this.injectOnFinish && this.failOnError()) {
+            this._injectError(span, me);
+            return false;
+        }
+    }
+
+    failOnError() {
+        return true;
+    }
+
+    private _injectErrorWithCallback(span: ThundraSpan,  me: any, callback: () => any): void {
+        if (this.counter % this.injectCountFreq === 0) {
+            const error = new Error(this.errorMessage);
+            error.name = this.errorType;
+            span.setErrorTag(error);
+            if (typeof(callback) === 'function') {
+                callback.apply(me, [error]);
+            }
+        }
+
+        this.counter++;
+    }
+
+    private _injectError(span: ThundraSpan,  me: any): void {
+        if (this.counter % this.injectCountFreq === 0) {
+            const error = new Error(this.errorMessage);
+            error.name = this.errorType;
+            span.setErrorTag(error);
+            this.counter++;
+            throw error;
+        }
+
+        this.counter++;
+    }
+}
+
+export default ErrorInjectorSpanListener;

--- a/src/plugins/listeners/ErrorInjectorSpanListener.ts
+++ b/src/plugins/listeners/ErrorInjectorSpanListener.ts
@@ -25,10 +25,14 @@ class ErrorInjectorSpanListener implements ThundraSpanListener {
         this.counter = 0;
     }
 
-    onSpanStarted(span: ThundraSpan, me: any, callback: () => any, args: any[]): boolean {
+    onSpanStarted(span: ThundraSpan, me: any, callback: () => any, args: any[], callbackAlreadyCalled?: boolean): boolean {
         if (callback && !this.injectOnFinish) {
-            this._injectErrorWithCallback(span, me, callback);
-            return true;
+            if (callbackAlreadyCalled === undefined || callbackAlreadyCalled === false) {
+                this._injectErrorWithCallback(span, me, callback);
+                return true;
+            }
+
+            return false;
         }
 
         if (!callback && !this.injectOnFinish && this.failOnError()) {
@@ -37,10 +41,14 @@ class ErrorInjectorSpanListener implements ThundraSpanListener {
         }
     }
 
-    onSpanFinished(span: ThundraSpan, me: any, callback: () => any, args: any[]): boolean {
+    onSpanFinished(span: ThundraSpan, me: any, callback: () => any, args: any[], callbackAlreadyCalled?: boolean): boolean {
         if (callback && this.injectOnFinish) {
-            this._injectErrorWithCallback(span, me, callback);
-            return true;
+            if (callbackAlreadyCalled === undefined || callbackAlreadyCalled === false) {
+                this._injectErrorWithCallback(span, me, callback);
+                return true;
+            }
+
+            return false;
         }
 
         if (!callback && this.injectOnFinish && this.failOnError()) {

--- a/src/plugins/listeners/FilteringSpanListener.ts
+++ b/src/plugins/listeners/FilteringSpanListener.ts
@@ -24,17 +24,17 @@ class FilteringSpanListener implements ThundraSpanListener {
         }
     }
 
-    onSpanStarted(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
+    onSpanStarted(span: ThundraSpan, me?: any, callback?: () => any, args?: any[], callbackAlreadyCalled?: boolean): boolean {
         if (this.spanFilterer.accept(span)) {
-            return this.listener.onSpanStarted(span, me, callback, args);
+            return this.listener.onSpanStarted(span, me, callback, args, callbackAlreadyCalled);
         }
 
         return false;
     }
 
-    onSpanFinished(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
+    onSpanFinished(span: ThundraSpan, me?: any, callback?: () => any, args?: any[], callbackAlreadyCalled?: boolean): boolean {
         if (this.spanFilterer.accept(span)) {
-            this.listener.onSpanFinished(span, me, callback, args);
+            this.listener.onSpanFinished(span, me, callback, args, callbackAlreadyCalled);
             return true;
         }
 

--- a/src/plugins/listeners/FilteringSpanListener.ts
+++ b/src/plugins/listeners/FilteringSpanListener.ts
@@ -1,0 +1,123 @@
+import ThundraSpanListener from './ThundraSpanListener';
+import SpanFilterer from './SpanFilterer';
+import ThundraSpan from '../../opentracing/Span';
+import { LISTENERS } from '../../Constants';
+import ThundraLogger from '../../ThundraLogger';
+import StandardSpanFilterer from './StandardSpanFilterer';
+import SpanFilter from './SpanFilter';
+
+class FilteringSpanListener implements ThundraSpanListener {
+    private listener: ThundraSpanListener;
+    private spanFilterer: SpanFilterer;
+
+    constructor(opt: any = {}) {
+        if (!opt.listener) {
+            return;
+        }
+
+        try {
+            this.listener = this._getListenerFromConfig(opt);
+            this.spanFilterer = new StandardSpanFilterer(this._getSpanFiltererFromConfig(opt));
+        } catch (err) {
+            ThundraLogger.getInstance().error(
+                `Cannot parse span listener config with reason: ${err.message}`);
+        }
+    }
+
+    onSpanStarted(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
+        if (this.spanFilterer.accept(span)) {
+            return this.listener.onSpanStarted(span, me, callback, args);
+        }
+
+        return false;
+    }
+
+    onSpanFinished(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
+        if (this.spanFilterer.accept(span)) {
+            this.listener.onSpanFinished(span, me, callback, args);
+            return true;
+        }
+
+        return false;
+    }
+
+    failOnError(): boolean {
+        return this.listener.failOnError();
+    }
+
+    private _getListenerFromConfig(opt: any): ThundraSpanListener {
+        const listenerClass = LISTENERS[opt.listener];
+        if (!listenerClass) {
+            throw new Error('No listener found with name: ' + opt.listener);
+        }
+
+        const listenerConfigs: any = {};
+        for (const key of Object.keys(opt)) {
+            if (key.startsWith('config.')) {
+                const value = opt[key];
+                const configName = key.substring('config.'.length, key.length);
+                listenerConfigs[configName] = value;
+            }
+        }
+
+        return new listenerClass(listenerConfigs);
+    }
+
+    private _getSpanFiltererFromConfig(opt: any): SpanFilter[] {
+        const spanFilters: SpanFilter[] = [];
+        const filterConfigs = this._getFiltererConfigs(opt);
+        for (const key of Object.keys(filterConfigs)) {
+            const filterConfig = filterConfigs[key];
+            const domainName = filterConfig.domainName;
+            const className = filterConfig.className;
+            const operationName = filterConfig.operationName;
+            const tags: any = {};
+
+            for (const configKey of Object.keys(filterConfig)) {
+                if (configKey.startsWith('tag.')) {
+                    const value = filterConfig[configKey];
+                    const configName = configKey.substring('tag.'.length, configKey.length);
+                    if (isNaN(parseFloat(value))) {
+                        if (value === 'true' || value === 'false') {
+                            tags[configName] = value === 'true' ? true : false;
+                        } else {
+                            tags[configName] = value;
+                        }
+                    } else {
+                        tags[configName] = parseFloat(value);
+                    }
+                }
+            }
+
+            spanFilters.push(new SpanFilter(domainName, className, operationName, tags));
+        }
+
+        return spanFilters;
+    }
+
+    private _getFiltererConfigs(opt: any): any {
+        const filterConfigs: any = {};
+
+        for (const key of Object.keys(opt)) {
+            if (key.startsWith('filter')) {
+                const value = opt[key];
+                const separator = key.indexOf('.');
+                if (separator > 0) {
+                    const filterId = key.substring(0, separator + 1);
+                    let filterConfig = filterConfigs[filterId];
+                    if (!filterConfig) {
+                        filterConfig = {};
+                        filterConfigs[filterId] = filterConfig;
+                    }
+                    // Cannot add more than 10 filters but it is ok for now.
+                    const filterPropName = key.substring(separator + 1, key.length);
+                    filterConfig[filterPropName] = value;
+                }
+            }
+        }
+
+        return filterConfigs;
+    }
+}
+
+export default FilteringSpanListener;

--- a/src/plugins/listeners/LatencyInjectorSpanListener.ts
+++ b/src/plugins/listeners/LatencyInjectorSpanListener.ts
@@ -19,16 +19,20 @@ class LatencyInjectorSpanListener implements ThundraSpanListener {
         this.randomizeDelay = JSON.parse(koalas(opt.randomizeDelay, this.DEFAULT_RANDOMIZE_DELAY));
     }
 
-    onSpanStarted(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
-        if (callback && !this.injectOnFinish) {
-            const sleep = this.randomizeDelay ? Utils.getRandomInt(this.delay) : this.delay;
-            Utils.sleep(sleep).then(() => {
-                if (typeof(callback) === 'function') {
-                    callback.apply(me, args);
-                }
-            });
+    onSpanStarted(span: ThundraSpan, me?: any, callback?: () => any, args?: any[], callbackAlreadyCalled?: boolean): boolean {
+        if (callbackAlreadyCalled === undefined || callbackAlreadyCalled === false) {
+            if (callback && !this.injectOnFinish) {
+                const sleep = this.randomizeDelay ? Utils.getRandomInt(this.delay) : this.delay;
+                Utils.sleep(sleep).then(() => {
+                    if (typeof(callback) === 'function') {
+                        callback.apply(me, args);
+                    }
+                });
+            }
+            return true;
         }
-        return true;
+
+        return false;
     }
 
     onSpanFinished(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {

--- a/src/plugins/listeners/LatencyInjectorSpanListener.ts
+++ b/src/plugins/listeners/LatencyInjectorSpanListener.ts
@@ -1,0 +1,56 @@
+import ThundraSpanListener from './ThundraSpanListener';
+import ThundraSpan from '../../opentracing/Span';
+import Utils from '../utils/Utils';
+
+const koalas = require('koalas');
+
+class LatencyInjectorSpanListener implements ThundraSpanListener {
+    private readonly DEFAULT_DELAY = 100;
+    private readonly DEFAULT_INJECT_ON_FINISH: boolean = false;
+    private readonly DEFAULT_RANDOMIZE_DELAY: boolean = false;
+
+    private injectOnFinish: boolean;
+    private delay: number;
+    private randomizeDelay: boolean;
+
+    constructor(opt: any = {}) {
+        this.injectOnFinish = JSON.parse(koalas(opt.injectOnFinish, this.DEFAULT_INJECT_ON_FINISH));
+        this.delay = JSON.parse(koalas(opt.delay, this.DEFAULT_DELAY));
+        this.randomizeDelay = JSON.parse(koalas(opt.randomizeDelay, this.DEFAULT_RANDOMIZE_DELAY));
+    }
+
+    onSpanStarted(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
+        if (callback && !this.injectOnFinish) {
+            const sleep = this.randomizeDelay ? Utils.getRandomInt(this.delay) : this.delay;
+            Utils.sleep(sleep).then(() => {
+                if (typeof(callback) === 'function') {
+                    callback.apply(me, args);
+                }
+            });
+        }
+        return true;
+    }
+
+    onSpanFinished(span: ThundraSpan, me?: any, callback?: () => any, args?: any[]): boolean {
+        if (callback && this.injectOnFinish) {
+            const sleep = this.randomizeDelay ? Utils.getRandomInt(this.delay) : this.delay;
+            Utils.sleep(sleep).then(() => {
+                if (typeof(callback) === 'function') {
+                    callback.apply(me, args);
+                }
+            });
+        }
+
+        return true;
+    }
+
+    failOnError() {
+        return false;
+    }
+
+    invokesCallback(): boolean {
+        return true;
+    }
+}
+
+export default LatencyInjectorSpanListener;

--- a/src/plugins/listeners/SpanFilter.ts
+++ b/src/plugins/listeners/SpanFilter.ts
@@ -1,0 +1,87 @@
+import ThundraSpan from '../../opentracing/Span';
+
+class SpanFilter {
+    private $domainName: string;
+    private $className: string;
+    private $operationName: string;
+    private $tags: any;
+
+    constructor(domainName: string, className: string, operationName: string, tags: any) {
+        this.$domainName = domainName;
+        this.$className = className;
+        this.$operationName = operationName;
+        this.$tags = tags ? tags : {};
+    }
+
+    get domainName(): string {
+        return this.$domainName;
+    }
+
+    set domainName(domainName: string) {
+         this.$domainName = domainName;
+    }
+
+    get className(): string {
+        return this.$className;
+    }
+
+    set className(className: string) {
+         this.$className = className;
+    }
+
+    get operationName(): string {
+        return this.$operationName;
+    }
+
+    set operationName(operationName: string) {
+         this.$operationName = operationName;
+    }
+
+    get tags(): string {
+        return this.$tags;
+    }
+
+    set tags(tags: string) {
+         this.$tags = tags;
+    }
+
+    getTag(key: string): any {
+        return this.$tags[key];
+    }
+
+    setTag(key: string, value: string): void {
+        this.$tags[key] = value;
+    }
+
+    accept(span: ThundraSpan): boolean {
+        let accepted = true;
+
+        if (this.domainName) {
+            accepted = this.domainName === span.domainName;
+        }
+
+        if (accepted && this.className) {
+            accepted = this.className === span.className;
+        }
+
+        if (accepted && this.operationName) {
+            accepted = this.operationName === span.operationName;
+        }
+
+        if (accepted) {
+            const filterTags = this.tags;
+            if (filterTags) {
+                for (const tagKey of Object.keys(filterTags)) {
+                    if (this.getTag(tagKey) !== span.getTag(tagKey)) {
+                        accepted = false;
+                        break;
+                    }
+                }
+            }
+        }
+        return accepted;
+    }
+
+}
+
+export default SpanFilter;

--- a/src/plugins/listeners/SpanFilterer.ts
+++ b/src/plugins/listeners/SpanFilterer.ts
@@ -1,0 +1,7 @@
+import ThundraSpan from '../../opentracing/Span';
+
+interface SpanFilterer {
+    accept(span: ThundraSpan): boolean;
+}
+
+export default SpanFilterer;

--- a/src/plugins/listeners/StandardSpanFilterer.ts
+++ b/src/plugins/listeners/StandardSpanFilterer.ts
@@ -1,0 +1,34 @@
+import SpanFilterer from './SpanFilterer';
+import ThundraSpan from '../../opentracing/Span';
+import SpanFilter from './SpanFilter';
+
+class StandardSpanFilterer implements SpanFilterer {
+    private spanFilters: SpanFilter[];
+
+    constructor(spanFilters: SpanFilter[]) {
+        this.spanFilters = spanFilters ? spanFilters : [];
+    }
+
+    accept(span: ThundraSpan): boolean {
+        if (!this.spanFilters || this.spanFilters.length === 0) {
+            return true;
+        }
+
+        for (const spanFilter of this.spanFilters) {
+            if (spanFilter.accept(span)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    addFilter(spanFilter: SpanFilter): void {
+        this.spanFilters.push(spanFilter);
+    }
+
+    clearFilters(): void {
+        this.spanFilters = [];
+    }
+}
+
+export default StandardSpanFilterer;

--- a/src/plugins/listeners/ThundraSpanListener.ts
+++ b/src/plugins/listeners/ThundraSpanListener.ts
@@ -1,8 +1,10 @@
 import ThundraSpan from '../../opentracing/Span';
 
 interface ThundraSpanListener {
-    onSpanStarted: (span: ThundraSpan, me?: any, callback?: () => any, args?: any []) => boolean;
-    onSpanFinished: (span: ThundraSpan, me?: any, callback?: () => any, args?: any []) => boolean;
+    onSpanStarted: (span: ThundraSpan, me?: any, callback?: () => any,
+                    args?: any[], callbackAlreadyCalled?: boolean) => boolean;
+    onSpanFinished: (span: ThundraSpan, me?: any, callback?: () => any,
+                     args?: any[], callbackAlreadyCalled?: boolean) => boolean;
     failOnError: () => boolean;
 }
 

--- a/src/plugins/listeners/ThundraSpanListener.ts
+++ b/src/plugins/listeners/ThundraSpanListener.ts
@@ -1,20 +1,9 @@
 import ThundraSpan from '../../opentracing/Span';
 
 interface ThundraSpanListener {
-
-    /**
-     * Called when {@link ThundraSpan span} has started.
-     *
-     * @param span the started {@link ThundraSpan span}
-     */
-    onSpanStarted: (span: ThundraSpan) => void;
-
-    /**
-     * Called when {@link ThundraSpan span} has finished.
-     *
-     * @param span the finished {@link ThundraSpan span}
-     */
-    onSpanFinished: (span: ThundraSpan) => void;
+    onSpanStarted: (span: ThundraSpan, me?: any, callback?: () => any, args?: any []) => boolean;
+    onSpanFinished: (span: ThundraSpan, me?: any, callback?: () => any, args?: any []) => boolean;
+    failOnError: () => boolean;
 }
 
 export default ThundraSpanListener;

--- a/src/plugins/support/InvocationSupport.ts
+++ b/src/plugins/support/InvocationSupport.ts
@@ -2,6 +2,7 @@ import ThundraLogger from '../../ThundraLogger';
 
 class InvocationSupport {
     static tags: any = {};
+    static functionName = '';
 
     static setTag(key: string, value: any): void {
         try {
@@ -27,6 +28,14 @@ class InvocationSupport {
 
     static removeTags(): void {
         InvocationSupport.tags = {};
+    }
+
+    static setFunctionName(functionName: string): void {
+        InvocationSupport.functionName = functionName;
+    }
+
+    static getFunctionName(): string {
+        return InvocationSupport.functionName;
     }
 }
 

--- a/test/instrumentation/automated.instrumentation.js
+++ b/test/instrumentation/automated.instrumentation.js
@@ -12,12 +12,9 @@ const automatic_instrumentation_test = function () {
         }],
     };
     
-    const traceConfig = new TraceConfig(traceConfigOptions);
-    const instrumenter = new Instrumenter(traceConfig);
-    
+    new TraceConfig(traceConfigOptions);
     const tracer = new ThundraTracer();
     
-    instrumenter.hookModuleCompile();
     const Automated = require('./utils/automated.instrumentation.util');
 
     const returnValue = Automated.test_function();
@@ -25,21 +22,19 @@ const automatic_instrumentation_test = function () {
     const spanList = tracer.getRecorder().spanList;
 
     assert.equal(spanList.length, 2);
-    assert.equal(spanList[0].className, 'Method');
-    assert.equal(spanList[0].operationName, 'test.instrumentation.utils.automated.instrumentation.util.f1');
-    assert.equal(spanList[0].tags['method.args'][0].name, 'a');
-    assert.equal(spanList[0].tags['method.args'][0].type, 'number');
-    assert.equal(spanList[0].tags['method.args'][0].value, 0);
-    assert.equal(spanList[0].tags['method.return_value'].type, 'number');
-    assert.equal(spanList[0].tags['method.return_value'].value, 1);
-
-    assert.equal(spanList[1].operationName, 'test.instrumentation.utils.automated.instrumentation.util.module.exports.test_function');
     assert.equal(spanList[1].className, 'Method');
-    assert.equal(spanList[1].tags['method.args'].length, 0);
+    assert.equal(spanList[1].operationName, 'test.instrumentation.utils.automated.instrumentation.util.f1');
+    assert.equal(spanList[1].tags['method.args'][0].name, 'a');
+    assert.equal(spanList[1].tags['method.args'][0].type, 'number');
+    assert.equal(spanList[1].tags['method.args'][0].value, 0);
     assert.equal(spanList[1].tags['method.return_value'].type, 'number');
-    assert.equal(spanList[1].tags['method.return_value'].value, returnValue);
+    assert.equal(spanList[1].tags['method.return_value'].value, 1);
 
-    instrumenter.unhookModuleCompile();
+    assert.equal(spanList[0].operationName, 'test.instrumentation.utils.automated.instrumentation.util.module.exports.test_function');
+    assert.equal(spanList[0].className, 'Method');
+    assert.equal(spanList[0].tags['method.args'].length, 0);
+    assert.equal(spanList[0].tags['method.return_value'].type, 'number');
+    assert.equal(spanList[0].tags['method.return_value'].value, returnValue);
 };
 
 automatic_instrumentation_test();

--- a/test/integration/aws.integration.test.js
+++ b/test/integration/aws.integration.test.js
@@ -1,9 +1,11 @@
 import AWS from './utils/aws.integration.utils';
 import AWSIntegration from '../../dist/plugins/integrations/AWSIntegration';
 import ThundraTracer from '../../dist/opentracing/Tracer';
+import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
 
 describe('AWS Integration', () => {
-    
+    InvocationSupport.setFunctionName('functionName');
+
     test('should instrument AWS DynamoDB calls ', () => { 
         const integration = new AWSIntegration({});
         const sdk = require('aws-sdk');
@@ -11,7 +13,7 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
+        
 
         return AWS.dynamo(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -42,7 +44,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.s3GetObject(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -70,7 +71,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.s3ListBuckets(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -91,14 +91,13 @@ describe('AWS Integration', () => {
         });
     });
 
-    test('should instrument AWS Lambda calls ', () => { 
+    test('should instrument AWS Lambda invoke call ', () => { 
         const integration = new AWSIntegration({});
         const sdk = require('aws-sdk');
 
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.lambda(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -119,6 +118,19 @@ describe('AWS Integration', () => {
             expect(span.tags['trigger.operationNames']).toEqual(['functionName']);
         });
     });
+
+    test('should instrument AWS Lambda calls ', () => { 
+        const integration = new AWSIntegration({});
+        const sdk = require('aws-sdk');
+
+        integration.wrap(sdk, {});
+        
+        const tracer = new ThundraTracer();
+
+        return AWS.lambdaGetAccountSettings(sdk).then(() => {
+            expect(tracer.getRecorder().spanList[0]).toBeTruthy();
+        });
+    });
     
     test('should instrument AWS SQS calls ', () => { 
         const integration = new AWSIntegration({});
@@ -127,7 +139,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.sqs(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -154,7 +165,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.sqs_list_queue(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -182,7 +192,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.sns(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -210,7 +219,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.sns_checkIfPhoneNumberIsOptedOut(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -233,7 +241,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.kinesis(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -259,7 +266,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.firehose(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];
@@ -285,7 +291,6 @@ describe('AWS Integration', () => {
         integration.wrap(sdk, {});
         
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return AWS.kms(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];

--- a/test/integration/es.integration.test.js
+++ b/test/integration/es.integration.test.js
@@ -1,0 +1,38 @@
+import ESIntegrations from '../../dist/plugins/integrations/ESIntegration';
+import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
+import ThundraTracer from '../../dist/opentracing/Tracer';
+import ES from './utils/es.integration.utils';
+
+describe('Elastic Search Integration', () => {
+    test('should instrument ES calls ', () => {
+        const integration = new ESIntegrations({});
+        const sdk = require('elasticsearch');
+        integration.wrap(sdk.Transport, {});
+
+        const tracer = new ThundraTracer();
+        InvocationSupport.setFunctionName('functionName');
+
+        return ES.query(sdk).then((data) => {
+            const span = tracer.getRecorder().spanList[0];
+            expect(span.operationName).toBe('localhost');
+            expect(span.className).toBe('ELASTICSEARCH');
+            expect(span.domainName).toBe('DB');
+
+            expect(span.tags['operation.type']).toBe('READ');
+            expect(span.tags['db.instance']).toBe('localhost');
+            expect(span.tags['db.host']).toBe('localhost');
+            expect(span.tags['db.port']).toBe('9200');
+            expect(span.tags['db.type']).toBe('elasticsearch');
+
+            expect(span.tags['topology.vertex']).toEqual(true);
+            expect(span.tags['trigger.domainName']).toEqual('API');
+            expect(span.tags['trigger.className']).toEqual('AWS-Lambda');
+            expect(span.tags['trigger.operationNames']).toEqual(['functionName']);
+
+            expect(span.tags['elasticsearch.url']).toEqual('/twitter/tweets/_search');
+            expect(span.tags['elasticsearch.method']).toEqual('POST');
+            expect(span.tags['elasticsearch.params']).toEqual('{}');
+            expect(span.tags['elasticsearch.body']).toEqual('{"query":{"match":{"body":"elasticsearch"}}}');
+        });
+    });
+});

--- a/test/integration/http.integration.test.js
+++ b/test/integration/http.integration.test.js
@@ -1,6 +1,7 @@
 import HttpIntegration from '../../dist/plugins/integrations/HttpIntegration';
 import ThundraTracer from '../../dist/opentracing/Tracer';
 import Http from './utils/http.integration.utils';
+import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
 
 describe('HTTP integration', () => {
     test('should instrument HTTP calls ', () => {
@@ -10,7 +11,7 @@ describe('HTTP integration', () => {
         integration.wrap(sdk, {});
 
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
+        InvocationSupport.setFunctionName('functionName');
 
         return Http.get(sdk).then(() => {
             const span = tracer.getRecorder().spanList[0];

--- a/test/integration/mysql.integration.test.js
+++ b/test/integration/mysql.integration.test.js
@@ -1,21 +1,55 @@
 
-import MySQLIntegration from '../../dist/plugins/integrations/MySQL2Integration';
+import MySQL2Integration from '../../dist/plugins/integrations/MySQL2Integration';
+import MySQLIntegration from '../../dist/plugins/integrations/MySQLIntegration';
 import ThundraTracer from '../../dist/opentracing/Tracer';
+import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
 import mysql from './utils/mysql.integration.utils';
 
 
 describe('MySQL2 Integration', () => {
+    InvocationSupport.setFunctionName('functionName');
+
     test('should instrument MySQL calls ', () => {
-        const integration = new MySQLIntegration({});
+        const integration = new MySQL2Integration({});
         const sdk = require('mysql2');
         const connection = require('mysql2/lib/connection.js');
         integration.wrap(connection, {});
 
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
-        return mysql.select(sdk).then((data) => {
+        return mysql.selectMySql2(sdk).then((data) => {
             const span = tracer.getRecorder().spanList[0];
+            expect(span.className).toBe('MYSQL');
+            expect(span.domainName).toBe('DB');
+
+            expect(span.tags['operation.type']).toBe('READ');
+            expect(span.tags['db.instance']).toBe('db');
+            expect(span.tags['db.user']).toBe('user');
+            expect(span.tags['db.host']).toBe('localhost');
+            expect(span.tags['db.port']).toBe(3306);
+            expect(span.tags['db.type']).toBe('mysql');
+            expect(span.tags['db.statement.type']).toBe('SELECT');
+            expect(span.tags['db.statement']).toBe('SELECT 1 + 1 AS solution');
+            expect(span.tags['topology.vertex']).toEqual(true);
+            expect(span.tags['trigger.domainName']).toEqual('API');
+            expect(span.tags['trigger.className']).toEqual('AWS-Lambda');
+            expect(span.tags['trigger.operationNames']).toEqual(['functionName']);
+        });
+    });
+});
+
+describe('MySQL Integration', () => {
+    test('should instrument MySQL calls ', () => {
+        const integration = new MySQLIntegration({});
+        const sdk = require('mysql');
+        const connection = require('mysql/lib/Connection.js');
+        integration.wrap(connection, {});
+
+        const tracer = new ThundraTracer();
+
+        return mysql.selectMySql(sdk).then((data) => {
+            const span = tracer.getRecorder().spanList[0];
+            
             expect(span.className).toBe('MYSQL');
             expect(span.domainName).toBe('DB');
 

--- a/test/integration/pg.integration.test.js
+++ b/test/integration/pg.integration.test.js
@@ -2,16 +2,18 @@
 import PostgreIntegration from '../../dist/plugins/integrations/PostgreIntegration';
 import ThundraTracer from '../../dist/opentracing/Tracer';
 import PG from './utils/pg.integration.utils';
+import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
 
 
 describe('PostgreSQL Integration', () => {
+    InvocationSupport.setFunctionName('functionName');
+
     test('should instrument PostgreSQL calls ', () => {
         const integration = new PostgreIntegration({});
         const sdk = require('pg');
         integration.wrap(sdk, {});
 
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return PG.select(sdk).then((data) => {
             const span = tracer.getRecorder().spanList[0];

--- a/test/integration/redis.integration.test.js
+++ b/test/integration/redis.integration.test.js
@@ -1,8 +1,11 @@
 import RedisIntegration from '../../dist/plugins/integrations/RedisIntegration';
 import ThundraTracer from '../../dist/opentracing/Tracer';
 import Redis from './utils/redis.integration.utils';
+import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
 
 describe('Redis Integration', () => {
+    InvocationSupport.setFunctionName('functionName');
+    
     test('should instrument Redis calls ', () => {
         const integration = new RedisIntegration({});
         const sdk = require('redis');
@@ -10,7 +13,6 @@ describe('Redis Integration', () => {
         integration.wrap(sdk, {});
 
         const tracer = new ThundraTracer();
-        tracer.functionName = 'functionName';
 
         return Redis.set(sdk).then((data) => {
             const spanList = tracer.getRecorder().spanList;
@@ -22,7 +24,7 @@ describe('Redis Integration', () => {
                 }
             });
 
-            expect(spanList.length).toBe(3);
+            expect(spanList.length).toBe(4);
 
             expect(writeCommandSpan.className).toBe('Redis');
             expect(writeCommandSpan.domainName).toBe('Cache');

--- a/test/integration/utils/aws.integration.utils.js
+++ b/test/integration/utils/aws.integration.utils.js
@@ -74,6 +74,19 @@ module.exports.lambda = (AWS) => {
     });
 };
 
+module.exports.lambdaGetAccountSettings = (AWS) => {
+    return new Promise((resolve, reject) => {
+        AWS.config.update({ region: 'us-west-2' });
+        const lambda = new AWS.Lambda();
+
+        lambda.getAccountSettings().promise().then((data) => {
+            return resolve(data);
+        }).catch((err) => {
+            return reject(err);
+        });
+    });
+};
+
 module.exports.sqs = (AWS) => {
     return new Promise((resolve) => {
         AWS.config.update({ region: 'us-west-2' });

--- a/test/integration/utils/es.integration.utils.js
+++ b/test/integration/utils/es.integration.utils.js
@@ -1,0 +1,25 @@
+module.exports.query = (es) => {
+    return new Promise((resolve) => {
+        var client = new es.Client({
+            host: 'http://localhost:9200'
+        });
+
+        const query = {
+            index: 'twitter',
+            type: 'tweets',
+            body: {
+                query: {
+                    match: {
+                        body: 'elasticsearch'
+                    }
+                }
+            }
+        };
+
+        client.search(query).then((data) => {
+            return resolve(data);
+        }).catch((err) => {
+            return resolve(err);
+        });
+    });
+};

--- a/test/integration/utils/mysql.integration.utils.js
+++ b/test/integration/utils/mysql.integration.utils.js
@@ -1,4 +1,4 @@
-module.exports.select = (mysql2) => {
+module.exports.selectMySql2 = (mysql2) => {
     return new Promise((resolve) => {
         const connection = mysql2.createConnection({
             host: 'localhost',
@@ -18,3 +18,25 @@ module.exports.select = (mysql2) => {
         });
     });
 };
+
+module.exports.selectMySql = (mysql) => {
+    return new Promise((resolve) => {
+        const connection = mysql.createConnection({
+            host: 'localhost',
+            user: 'user',
+            database: 'db',
+            password: 'userpass',
+        });
+
+        connection.query('SELECT 1 + 1 AS solution', () => {
+            connection.end((err, data) => {
+                if (err) {
+                    // Resolve even though there is an error.
+                    return resolve(err);
+                }
+                return resolve(data);
+            });
+        });
+    });
+};
+

--- a/test/integration/utils/pg.integration.utils.js
+++ b/test/integration/utils/pg.integration.utils.js
@@ -11,8 +11,8 @@ module.exports.select = (pg) => {
 
         client.connect();
         
-        client.query('SELECT $1::text as message', ['Hello world!'], () => {
-            client.end((err, data) => {
+        client.query('SELECT $1::text as message', ['Hello world!'], (err, data) => {
+            client.end(() => {
                 if (err) {
                     // Resolve even though there is an error.
                     return resolve(err);

--- a/test/opentracing/tracer.test.js
+++ b/test/opentracing/tracer.test.js
@@ -53,15 +53,15 @@ describe('Recorder', () => {
 
         const childSpan = tracer.startSpan('child', { childOf: parentSpan });
 
-        childSpan.finish();
         parentSpan.finish();
+        childSpan.finish();
 
         it('should set log and tag relations', () => {
-            expect(tracer.recorder.getSpanList()[1].getOperationName()).toEqual('parent');
-            expect(tracer.recorder.getSpanList()[1].getTag('tag-key')).toEqual('tagValue');
-            expect(tracer.recorder.getSpanList()[1].logs[0].timestamp).not.toBeNull();
+            expect(tracer.recorder.getSpanList()[0].getOperationName()).toEqual('parent');
+            expect(tracer.recorder.getSpanList()[0].getTag('tag-key')).toEqual('tagValue');
+            expect(tracer.recorder.getSpanList()[0].logs[0].timestamp).not.toBeNull();
             expect(tracer.recorder.getSpanList().length).toEqual(2);
-            expect(tracer.recorder.getSpanList()[0].getOperationName()).toEqual('child');
+            expect(tracer.recorder.getSpanList()[1].getOperationName()).toEqual('child');
         });
 
     });
@@ -74,13 +74,13 @@ describe('Recorder', () => {
             references: [new Reference('follows_from', parentSpan.context())]
         });
 
-        childSpan.finish();
         parentSpan.finish();
-
+        childSpan.finish();
+        
         it('should set log and tag relations', () => {
-            expect(tracer.recorder.getSpanList()[1].getOperationName()).toEqual('parent');
+            expect(tracer.recorder.getSpanList()[0].getOperationName()).toEqual('parent');
             expect(tracer.recorder.getSpanList().length).toEqual(2);
-            expect(tracer.recorder.getSpanList()[0].getOperationName()).toEqual('child');
+            expect(tracer.recorder.getSpanList()[1].getOperationName()).toEqual('child');
         });
 
     });

--- a/test/plugins/listener/error.injector.span.listener.test.js
+++ b/test/plugins/listener/error.injector.span.listener.test.js
@@ -1,0 +1,108 @@
+import ErrorInjectorSpanListener from '../../../dist/plugins/listeners/ErrorInjectorSpanListener';
+import ThundraTracer from '../../../dist/opentracing/Tracer';
+
+describe('ErrorInjectorSpanListener', () => {
+    const tracer = new ThundraTracer({});
+
+    it('Should init default configurations if empty opt provided', () => {
+        // Arrange
+        const opt = {};
+        
+        //Act
+        const listener = new ErrorInjectorSpanListener(opt);
+     
+        // Assert
+        expect(listener.counter).toBe(0);
+        expect(listener.injectCountFreq).toBe(listener.DEFAULT_INJECT_COUNT_FREQ);
+        expect(listener.errorMessage).toBe(listener.DEFAULT_ERROR_MESSAGE);
+        expect(listener.errorType).toBe(listener.DEFAULT_ERROR_TYPE);
+        expect(listener.injectOnFinish).toBe(listener.DEFAULT_INJECT_ON_FINISH);
+    });
+
+    it('Should inject error according to the error frequency', () => {
+        // Arrange
+        const opt = {
+            injectCountFreq: 5,
+        };
+        const listener = new ErrorInjectorSpanListener(opt);
+        const span = tracer.startSpan('test span');
+        let injectedErrorCount = 0;
+
+        // Act
+        for (var i = 0; i < 50; i++) {
+            try {
+                listener.onSpanStarted(span);
+            } catch (err) {
+                injectedErrorCount++;
+            }
+        }
+
+        // Assert
+        expect(injectedErrorCount).toBe(10);
+    });
+
+    it('Should inject error with message and type', () => {
+        // Arrange
+        const opt = {
+            injectCountFreq: 1000,
+            errorType: 'MyError',
+            errorMessage: 'This is an error!',
+        };
+
+        const listener = new ErrorInjectorSpanListener(opt);
+        const span = tracer.startSpan('test span');
+
+        // Act
+        try {
+            listener.onSpanStarted(span);
+            // eslint-disable-next-line no-empty
+        } catch (err) {
+
+        }
+
+        // Assert
+        expect(span.getTag('error')).toBeTruthy();
+        expect(span.getTag('error.kind')).toBe('MyError');
+        expect(span.getTag('error.message')).toBe('This is an error!');
+        expect(span.getTag('error.code')).not.toBeTruthy();
+        expect(span.getTag('error.stack')).toBeTruthy();
+    });
+
+    it('Should inject error on span finish', () => {
+        // Arrange
+        const opt = {
+            injectOnFinish: true
+        };
+
+        const listener = new ErrorInjectorSpanListener(opt);
+        const span = tracer.startSpan('test span');
+
+        // Act
+        //onSpanStarted should not throw exception
+        listener.onSpanStarted(span);
+        try {
+            listener.onSpanFinished(span);
+            // eslint-disable-next-line no-empty
+        } catch (err) {
+        }
+
+        // Assert
+        expect(span.getTag('error')).toBeTruthy();
+    });
+
+    it('Should invoke call back when callback is passed', () => {
+        // Arrange
+        const opt = {};
+
+        const listener = new ErrorInjectorSpanListener(opt);
+        const span = tracer.startSpan('test span');
+        const callback = jest.fn();
+        const args = ['argument1', 1];
+        // Act    
+        listener.onSpanStarted(span, this, callback, args);
+
+        // Assert
+        expect(listener.counter).toBe(1);
+        expect(callback).toBeCalledWith(new Error(listener.DEFAULT_ERROR_MESSAGE));
+    });
+});

--- a/test/plugins/listener/filtering.span.listener.test.js
+++ b/test/plugins/listener/filtering.span.listener.test.js
@@ -1,0 +1,37 @@
+import FilteringSpanListener from '../../../dist/plugins/listeners/FilteringSpanListener';
+import ErrorInjectorSpanListener from '../../../dist/plugins/listeners/ErrorInjectorSpanListener';
+import StandardSpanFilterer from '../../../dist/plugins/listeners/StandardSpanFilterer';
+import SpanFilter from '../../../dist/plugins/listeners/SpanFilter';
+import ThundraSpan from '../../../dist/opentracing/Span';
+
+describe('FilteringSpanListener', () => {
+
+    it('Should call function callback if filter matches and not call if it does not', () => {
+        // Arrange
+        const filteringListener = new FilteringSpanListener();
+
+        filteringListener.listener = new ErrorInjectorSpanListener();
+
+        filteringListener.spanFilterer = new StandardSpanFilterer();
+
+        const filter =  new SpanFilter();
+        filter.className = 'HTTP';
+        filteringListener.spanFilterer.addFilter(filter);
+
+        const matchingSpan = new ThundraSpan();
+        matchingSpan.className = 'HTTP';
+        const matchingCallback = jest.fn();
+
+        const nonMatchingSpan = new ThundraSpan();
+        nonMatchingSpan.className = 'AWS-SQS';
+        const nonMatchingCallback = jest.fn();
+        
+        //Act
+        filteringListener.onSpanStarted(matchingSpan, this, matchingCallback, [2, 'value']);
+        const callbackCalled = filteringListener.onSpanStarted(nonMatchingSpan, this, nonMatchingCallback, [2, 'value']);
+        
+        // Assert
+        expect(matchingCallback).toBeCalledWith(new Error(filteringListener.listener.DEFAULT_ERROR_MESSAGE));
+        expect(callbackCalled).toBe(false);
+    });
+});

--- a/test/plugins/listener/latency.injector.span.listener.test.js
+++ b/test/plugins/listener/latency.injector.span.listener.test.js
@@ -1,0 +1,74 @@
+import LatencyInjectorSpanListener from '../../../dist/plugins/listeners/LatencyInjectorSpanListener';
+import ThundraSpan from '../../../dist/opentracing/Span';
+
+describe('LatencyInjectorSpanListener', () => {
+
+    it('Should init default configurations if empty opt provided', () => {
+        // Arrange
+        const opt = {};
+        
+        //Act
+        const listener = new LatencyInjectorSpanListener(opt);
+     
+        // Assert
+        expect(listener.injectOnFinish).toBe(false);
+        expect(listener.delay).toBe(100);
+        expect(listener.randomizeDelay).toBe(false);
+    });
+
+
+    it('Should init with valid options', () => {
+        // Arrange
+        const opt = {
+            injectOnFinish: true,
+            delay: 200,
+            randomizeDelay: true,
+        };
+        
+        //Act
+        const listener = new LatencyInjectorSpanListener(opt);
+     
+        // Assert
+        expect(listener.injectOnFinish).toBe(true);
+        expect(listener.delay).toBe(200);
+        expect(listener.randomizeDelay).toBe(true);
+    });
+
+    it('Should not call function callback before delay', (done) => {
+        // Arrange
+        const opt = {
+            delay: 200
+        };
+        
+        //Act
+        const listener = new LatencyInjectorSpanListener(opt);
+        const span = new ThundraSpan();
+        const callback = jest.fn();
+        listener.onSpanStarted(span, this, callback, []);
+
+        // Assert        
+        setTimeout(() => {
+            expect(callback).not.toBeCalled();
+            done();
+        }, 100);
+    });
+
+    it('Should call function callback after delay', (done) => {
+        // Arrange
+        const opt = {
+            delay: 200
+        };
+        
+        //Act
+        const listener = new LatencyInjectorSpanListener(opt);
+        const span = new ThundraSpan();
+        const callback = jest.fn();
+        listener.onSpanStarted(span, this, callback, [2,'value']);
+
+        // Assert        
+        setTimeout(() => {
+            expect(callback).toBeCalledWith(2,'value');
+            done();
+        }, 210);
+    });
+});

--- a/test/plugins/listener/listener.config.test.js
+++ b/test/plugins/listener/listener.config.test.js
@@ -1,0 +1,99 @@
+import ThundraTracer from '../../../dist/opentracing/Tracer';
+import Utils from '../../../dist/plugins/utils/Utils';
+
+describe('Thundra Tracer', () => {
+
+    it('Should read listener config from environment variable with multiple filters and listener', () => {
+        // Arrange
+        const tracer = new ThundraTracer({});
+
+        process.env['thundra_agent_lambda_trace_span_listener'] = 'FilteringSpanListener[listener=LatencyInjectorSpanListener,config.delay=370,'+
+        'config.injectOnFinish=true,config.randomizeDelay=true,'+
+        'filter1.className=AWS-SQS,filter1.domainName=Messaging,filter1.tag.foo=bar,' +
+        'filter2.className=HTTP,filter2.operationName=http_request,filter2.tag.http.host=foobar.com]';
+
+        //Act
+        const listeners = Utils.registerSpanListenersFromConfigurations(tracer);
+        
+        //Assert
+        expect(listeners.length).toBe(1);
+        
+        const listener = listeners[0];
+    
+        expect(listener.listener).toBeTruthy();
+        expect(listener.spanFilterer).toBeTruthy();
+        expect(listener.onSpanStarted).toBeTruthy();
+        expect(listener.onSpanFinished).toBeTruthy();
+
+        expect(listener.listener.delay).toBe(370);
+        expect(listener.listener.randomizeDelay).toBe(true);
+        expect(listener.listener.injectOnFinish).toBe(true);
+        
+        expect(listener.spanFilterer.spanFilters.length).toBe(2);  
+        
+        expect(listener.spanFilterer.spanFilters[0].domainName).toBe('Messaging');       
+        expect(listener.spanFilterer.spanFilters[0].className).toBe('AWS-SQS');   
+        expect(listener.spanFilterer.spanFilters[0].getTag('foo')).toBe('bar');    
+        
+        expect(listener.spanFilterer.spanFilters[1].operationName).toBe('http_request');       
+        expect(listener.spanFilterer.spanFilters[1].className).toBe('HTTP');   
+        expect(listener.spanFilterer.spanFilters[1].getTag('http.host')).toBe('foobar.com');
+
+        process.env['thundra_agent_lambda_trace_span_listener'] = null;
+    });
+
+    it('Should read listener config from environment variable with multiple filters and listener', () => {
+
+        // Arrange
+        const tracer = new ThundraTracer({});
+
+        process.env['thundra_agent_lambda_trace_span_listener'] = 'FilteringSpanListener[listener=ErrorInjectorSpanListener,config.errorType=NameError,' + 
+        'config.errorMessage="foo",config.injectOnFinish=true,config.injectCountFreq=3,' + 
+        'filter.className=AWS-SQS,filter.domainName=Messaging,filter.tag.foo=bar]';
+
+        //Act
+        const listeners = Utils.registerSpanListenersFromConfigurations(tracer);
+        
+        //Assert
+        expect(listeners.length).toBe(1);
+        
+        const listener = listeners[0];
+    
+        expect(listener.listener).toBeTruthy();
+        expect(listener.spanFilterer).toBeTruthy();
+        expect(listener.onSpanStarted).toBeTruthy();
+        expect(listener.onSpanFinished).toBeTruthy();
+
+        expect(listener.listener.injectCountFreq).toBe(3);
+        expect(listener.listener.injectOnFinish).toBe(true);
+        expect(listener.listener.errorType).toBe('NameError');
+        expect(listener.listener.errorMessage).toBe('foo');
+        
+        expect(listener.spanFilterer.spanFilters.length).toBe(1);  
+        
+        expect(listener.spanFilterer.spanFilters[0].domainName).toBe('Messaging');       
+        expect(listener.spanFilterer.spanFilters[0].className).toBe('AWS-SQS');   
+        expect(listener.spanFilterer.spanFilters[0].getTag('foo')).toBe('bar');    
+        
+
+        process.env['thundra_agent_lambda_trace_span_listener'] = null;
+        tracer.destroy();
+    });
+
+    it('Should not add invalid listener', () => {
+
+        // Arrange
+        const tracer = new ThundraTracer({});
+
+        process.env['thundra_agent_lambda_trace_span_listener'] = 'InvalidSpanListener[]';
+
+        //Act
+        const listeners = Utils.registerSpanListenersFromConfigurations(tracer);
+        
+        //Assert
+        expect(listeners.length).toBe(0);
+       
+        process.env['thundra_agent_lambda_trace_span_listener'] = null;
+        tracer.destroy();
+    });
+});   


### PR DESCRIPTION
- Implement `ErrorInjectorSpanListener`,  `FilteringSpanListener` and `LatencyInjectorSpanListener`
- Fixes #47 
- Implement ES and MySQL V1 integrations
- Use InvocationSupport to pass functionName to Integrations
- Implement sampling only Timed  out Invocations
- Fix lambda timing out when used with https://www.npmjs.com/package/serverless-mysql 