### PR TITLE
Handle `ECONNRESET` error when keepAlive connection is terminated by …

### DIFF
--- a/src/Reporter.ts
+++ b/src/Reporter.ts
@@ -81,7 +81,7 @@ class Reporter {
                     break;
                 }
 
-                batch.push(Utils.stripCommonFields(report.data  as BaseMonitoringData));
+                batch.push(Utils.stripCommonFields(report.data as BaseMonitoringData));
             }
 
             compositeData.allMonitoringData = batch;
@@ -133,7 +133,13 @@ class Reporter {
             }
         });
 
-        await Promise.all(reportPromises).catch((err) => {
+        await Promise.all(reportPromises).catch(async (err) => {
+            if (err.code === 'ECONNRESET') {
+                ThundraLogger.getInstance().debug(
+                    'Keep Alive connection reset by server. Will send monitoring data again.');
+                await this.sendReports();
+                return;
+            }
             ThundraLogger.getInstance().error(err);
         });
     }


### PR DESCRIPTION
…the server. In a long-running lambda container keep-alive connections are reset by our collector servers due to nginx config for `keepalive_timeout` is 30 seconds. If a request fails due to this error, we do not log the error but we try to send the data again otherwise we miss monitoring data.