### PR TITLE
Response without body accepted as a valid response

### DIFF
--- a/src/plugins/utils/Utils.ts
+++ b/src/plugins/utils/Utils.ts
@@ -500,7 +500,7 @@ class Utils {
         if (!response) {
             return false;
         }
-        return response.statusCode && typeof response.statusCode === 'number' && response.body;
+        return response.statusCode && typeof response.statusCode === 'number';
     }
 }
 


### PR DESCRIPTION
`response.body` check removed from `isValidResponse` since it doesn't exist in HTTP 304 responses.

According to HTTP [specs](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html):

> All 1xx (informational), 204 (no content), and 304 (not modified) responses MUST NOT include a message-body. All other responses do include a message-body, although it MAY be of zero length.

