### PR TITLE
Renamed `thundra-wrapper.test.js` as `lambda-wrapper.test.js` and …

### DIFF
--- a/src/application/ApplicationManager.ts
+++ b/src/application/ApplicationManager.ts
@@ -1,6 +1,6 @@
 import { ApplicationInfoProvider } from './ApplicationInfoProvider';
 import { ApplicationInfo } from './ApplicationInfo';
-import GlobalApplicationInfoProvider from './GlobalApplicationInfoProvider';
+import { GlobalApplicationInfoProvider } from './GlobalApplicationInfoProvider';
 
 /**
  * Mediator class for application level stuff.

--- a/src/application/GlobalApplicationInfoProvider.ts
+++ b/src/application/GlobalApplicationInfoProvider.ts
@@ -8,7 +8,7 @@ import Utils from '../utils/Utils';
  * {@link ApplicationInfoProvider} implementation which provides {@link ApplicationInfo}
  * based on underlying platform and configuration.
  */
-export default class GlobalApplicationInfoProvider implements ApplicationInfoProvider {
+export class GlobalApplicationInfoProvider implements ApplicationInfoProvider {
 
     private applicationInfoProvider: ApplicationInfoProvider;
     private applicationInfo: ApplicationInfo;

--- a/test/mocks/mocks.js
+++ b/test/mocks/mocks.js
@@ -1,4 +1,4 @@
-import {LambdaContextProvider} from '../../dist/wrappers/lambda/LambdaContextProvider';
+import { LambdaContextProvider } from '../../dist/wrappers/lambda/LambdaContextProvider';
 import ExecutionContext from '../../dist/context/ExecutionContext';
 import ThundraTracer from '../../dist/opentracing/Tracer';
 

--- a/test/plugins/application.support.test.js
+++ b/test/plugins/application.support.test.js
@@ -1,13 +1,11 @@
 import ConfigProvider from '../../dist/config/ConfigProvider';
 import ConfigNames from '../../dist/config/ConfigNames';
+import { ApplicationManager } from '../../dist/application/ApplicationManager';
+import Utils from '../../dist/utils/Utils';
 
 import TestUtils from '../utils';
 
-import {ApplicationManager} from '../../dist/application/ApplicationManager';
-import {LambdaApplicationInfoProvider} from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
-import Utils from '../../dist/utils/Utils';
-
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
+ApplicationManager.setApplicationInfoProvider(null);
 
 beforeEach(() => {
     TestUtils.clearEnvironmentVariables();

--- a/test/plugins/console.shim.filter.test.js
+++ b/test/plugins/console.shim.filter.test.js
@@ -1,15 +1,14 @@
 import ConfigProvider from '../../dist/config/ConfigProvider';
 import ConfigNames from '../../dist/config/ConfigNames';
 import LogPlugin from '../../dist/plugins/Log';
-import { createMockPluginContext, createMockBeforeInvocationData } from '../mocks/mocks';
-import {ApplicationManager} from '../../dist/application/ApplicationManager';
-import {LambdaApplicationInfoProvider} from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
-
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
-
-import TestUtils from '../utils';
+import { ApplicationManager } from '../../dist/application/ApplicationManager';
 import ExecutionContext from '../../dist/context/ExecutionContext';
 import ExecutionContextManager from '../../dist/context/ExecutionContextManager';
+
+import TestUtils from '../utils';
+import { createMockPluginContext } from '../mocks/mocks';
+
+ApplicationManager.setApplicationInfoProvider(null);
 
 beforeEach(() => {
     TestUtils.clearEnvironmentVariables();

--- a/test/plugins/console.shim.test.js
+++ b/test/plugins/console.shim.test.js
@@ -1,11 +1,11 @@
 import LogPlugin from '../../dist/plugins/Log';
-import { createMockPluginContext, createMockBeforeInvocationData } from '../mocks/mocks';
-import {ApplicationManager} from '../../dist/application/ApplicationManager';
-import {LambdaApplicationInfoProvider} from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
+import { ApplicationManager } from '../../dist/application/ApplicationManager';
 import ExecutionContext from '../../dist/context/ExecutionContext';
 import ExecutionContextManager from '../../dist/context/ExecutionContextManager';
 
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
+import { createMockPluginContext } from '../mocks/mocks';
+
+ApplicationManager.setApplicationInfoProvider(null);
 
 describe('log plugin shim console', () => {
     it('should capture console.log statements', () => {  

--- a/test/plugins/invocation.test.js
+++ b/test/plugins/invocation.test.js
@@ -1,11 +1,11 @@
 import Invocation from '../../dist/plugins/Invocation';
 import ExecutionContext from '../../dist/context/ExecutionContext';
 import ExecutionContextManager from '../../dist/context/ExecutionContextManager';
-import { createMockPluginContext } from '../mocks/mocks';
 import { ApplicationManager } from '../../dist/application/ApplicationManager';
-import { LambdaApplicationInfoProvider } from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
 
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
+import { createMockPluginContext } from '../mocks/mocks';
+
+ApplicationManager.setApplicationInfoProvider(null);
 
 const pluginContext = createMockPluginContext();
 

--- a/test/plugins/log.test.js
+++ b/test/plugins/log.test.js
@@ -1,11 +1,11 @@
 import LogPlugin from '../../dist/plugins/Log';
 import ExecutionContext from '../../dist/context/ExecutionContext';
 import ExecutionContextManager from '../../dist/context/ExecutionContextManager';
-import { createMockPluginContext } from '../mocks/mocks';
 import {ApplicationManager} from '../../dist/application/ApplicationManager';
-import {LambdaApplicationInfoProvider} from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
 
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
+import { createMockPluginContext } from '../mocks/mocks';
+
+ApplicationManager.setApplicationInfoProvider(null);
 
 describe('log', () => {
     describe('constructor', () => {

--- a/test/plugins/metric.test.js
+++ b/test/plugins/metric.test.js
@@ -2,11 +2,11 @@ import Metric from '../../dist/plugins/Metric';
 import Utils from '../../dist/utils/Utils';
 import ExecutionContext from '../../dist/context/ExecutionContext';
 import ExecutionContextManager from '../../dist/context/ExecutionContextManager';
-import { createMockPluginContext, createMockBeforeInvocationData } from '../mocks/mocks';
 import { ApplicationManager } from '../../dist/application/ApplicationManager';
-import { LambdaApplicationInfoProvider } from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
 
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
+import { createMockPluginContext } from '../mocks/mocks';
+
+ApplicationManager.setApplicationInfoProvider(null);
 
 Utils.readProcIoPromise = jest.fn(() => {
     return new Promise((resolve, reject) => {

--- a/test/plugins/trace.test.js
+++ b/test/plugins/trace.test.js
@@ -4,19 +4,19 @@ import InvocationSupport from '../../dist/plugins/support/InvocationSupport';
 import InvocationTraceSupport from '../../dist/plugins/support/InvocationTraceSupport';
 import TraceConfig from '../../dist/plugins/config/TraceConfig';
 import * as LambdaExecutor from '../../dist/wrappers/lambda/LambdaExecutor';
+import { ApplicationManager } from '../../dist/application/ApplicationManager';
+
 import {
     createMockPluginContext, createMockApiGatewayProxy, createMockLambdaExecContext,
     createMockSNSEvent, createMockSQSEvent, createMockClientContext, createBatchMockSQSEventDifferentIds,
     createBatchMockSQSEventSameIds, createBatchMockSNSEventWithDifferentIds, createBatchMockSNSEventWithSameIds
 } from '../mocks/mocks';
 import * as mockAWSEvents from '../mocks/aws.events.mocks';
-import { ApplicationManager } from '../../dist/application/ApplicationManager';
-import { LambdaApplicationInfoProvider } from '../../dist/wrappers/lambda/LambdaApplicationInfoProvider';
 
 const md5 = require('md5');
 const flatten = require('lodash.flatten');
 
-ApplicationManager.setApplicationInfoProvider(new LambdaApplicationInfoProvider());
+ApplicationManager.setApplicationInfoProvider(null);
 
 const pluginContext = createMockPluginContext();
 

--- a/test/wrappers/lambda/lambda-wrapper.test.js
+++ b/test/wrappers/lambda/lambda-wrapper.test.js
@@ -1,13 +1,13 @@
-import LambdaHandlerWrapper from '../dist/wrappers/lambda/LambdaHandlerWrapper';
-import ConfigProvider from '../dist/config/ConfigProvider';
-import ConfigNames from '../dist/config/ConfigNames';
-import { createMockContext, createMockReporterInstance, createMockPlugin, createMockPluginContext, createMockPromise } from './mocks/mocks';
-import HttpError from '../dist/error/HttpError';
-import TimeoutError from '../dist/error/TimeoutError';
-import ExecutionContext from '../dist/context/ExecutionContext';
-import ExecutionContextManager from '../dist/context/ExecutionContextManager';
+import LambdaHandlerWrapper from '../../../dist/wrappers/lambda/LambdaHandlerWrapper';
+import ConfigProvider from '../../../dist/config/ConfigProvider';
+import ConfigNames from '../../../dist/config/ConfigNames';
+import HttpError from '../../../dist/error/HttpError';
+import TimeoutError from '../../../dist/error/TimeoutError';
+import ExecutionContext from '../../../dist/context/ExecutionContext';
+import ExecutionContextManager from '../../../dist/context/ExecutionContextManager';
 
-import TestUtils from './utils.js';
+import TestUtils from '../../utils.js';
+import { createMockContext, createMockReporterInstance, createMockPlugin, createMockPluginContext, createMockPromise } from '../../mocks/mocks';
 
 beforeEach(() => {
     TestUtils.clearEnvironmentVariables();
@@ -19,7 +19,7 @@ const pluginContext = createMockPluginContext();
 jest.useFakeTimers();
 jest.setTimeout(10000);
 
-describe('thundra wrapper', () => {
+describe('lambda wrapper', () => {
 
     const originalThis = this;
     const originalEvent = { key1: 'value2', key2: 'value2' };


### PR DESCRIPTION
… got rid of `LambdaApplicationInfoProvider` in tests