### PR TITLE
Add thundra_agent_invocation_sample_onerror Environment Variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thundra/core",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/config/ConfigMetadata.ts
+++ b/src/config/ConfigMetadata.ts
@@ -109,6 +109,10 @@ export const ConfigMetadata: {[key: string]: { type: string, defaultValue?: any 
         type: 'boolean',
         defaultValue: false,
     },
+    [ConfigNames.THUNDRA_INVOCATION_SAMPLE_ONERROR]: {
+        type: 'boolean',
+        defaultValue: false,
+    },
     [ConfigNames.THUNDRA_TRACE_INSTRUMENT_DISABLE]: {
         type: 'boolean',
         defaultValue: false,

--- a/src/config/ConfigNames.ts
+++ b/src/config/ConfigNames.ts
@@ -83,6 +83,11 @@ class ConfigNames {
 
     /////////////////////////////////////////////////////////////////////////////
 
+    public static readonly THUNDRA_INVOCATION_SAMPLE_ONERROR: string =
+        'thundra.agent.invocation.sample.onerror';
+
+    /////////////////////////////////////////////////////////////////////////////
+
     public static readonly THUNDRA_TRACE_INSTRUMENT_DISABLE: string =
         'thundra.agent.trace.instrument.disable';
     public static readonly THUNDRA_TRACE_INSTRUMENT_TRACEABLECONFIG: string =

--- a/src/context/ExecutionContext.ts
+++ b/src/context/ExecutionContext.ts
@@ -33,6 +33,7 @@ export default class ExecutionContext {
     applicationResourceName: string;
     captureLog: boolean;
     logs: LogData[];
+    reportingDisabled: boolean;
 
     constructor(opts: any = {}) {
         this.startTimestamp = opts.startTimestamp || 0;

--- a/src/opentracing/Span.ts
+++ b/src/opentracing/Span.ts
@@ -83,6 +83,14 @@ class ThundraSpan extends Span {
     }
 
     /**
+     * Checks whether the span has error tag
+     * @return {boolean} {@code true} if the span has error tags, {@code false} otherwise
+     */
+    hasErrorTag(): boolean {
+        return this.getTag('error');
+    }
+
+    /**
      * Closes the span
      * @param finishTime the finish time
      */
@@ -94,7 +102,7 @@ class ThundraSpan extends Span {
 
         this.finishTime = finishTime;
         if (this.spanContext.sampled) {
-            this.parentTracer._record(this, {disableActiveSpanHandling: true});
+            this.parentTracer._record(this, { disableActiveSpanHandling: true });
         }
     }
 
@@ -105,7 +113,7 @@ class ThundraSpan extends Span {
      * @param args the arguments to be passed to callback
      * @param finishTime the finish time
      */
-    closeWithCallback(me: any, callback: () => any, args: any[] , finishTime: number = Date.now()) {
+    closeWithCallback(me: any, callback: () => any, args: any[], finishTime: number = Date.now()) {
         if (this.finishTime !== 0) {
             ThundraLogger.debug(`<Span> Span with name ${this.operationName} is already closed`);
             return;
@@ -113,7 +121,7 @@ class ThundraSpan extends Span {
 
         this.finishTime = finishTime;
         if (this.spanContext.sampled) {
-            this.parentTracer._record(this, {disableActiveSpanHandling: true, me, callback, args});
+            this.parentTracer._record(this, { disableActiveSpanHandling: true, me, callback, args });
         }
     }
 
@@ -153,7 +161,7 @@ class ThundraSpan extends Span {
                 transactionId: parent.transactionId,
             });
         } else {
-                spanContext = new ThundraSpanContext({
+            spanContext = new ThundraSpanContext({
                 traceId: this.rootTraceId,
                 spanId: Utils.generateId(),
                 transactionId: this.transactionId,
@@ -212,7 +220,7 @@ class ThundraSpan extends Span {
 
         this.finishTime = finishTime;
         if (this.spanContext.sampled) {
-            this.parentTracer._record(this, {disableActiveSpanHandling: false});
+            this.parentTracer._record(this, { disableActiveSpanHandling: false });
         }
     }
 
@@ -231,9 +239,9 @@ class ThundraSpan extends Span {
 }
 
 export enum SpanEvent {
-  SPAN_START,
-  SPAN_INITIALIZE,
-  SPAN_FINISH,
+    SPAN_START,
+    SPAN_INITIALIZE,
+    SPAN_FINISH,
 }
 
 export default ThundraSpan;

--- a/src/plugins/Trace.ts
+++ b/src/plugins/Trace.ts
@@ -23,8 +23,10 @@ export default class Trace {
 
     pluginOrder: number = 1;
     pluginContext: PluginContext;
-    hooks: { 'before-invocation': (execContext: ExecutionContext) => void;
-            'after-invocation': (execContext: ExecutionContext) => void; };
+    hooks: {
+        'before-invocation': (execContext: ExecutionContext) => void;
+        'after-invocation': (execContext: ExecutionContext) => void;
+    };
     config: TraceConfig;
     integrationsMap: Map<string, Integration>;
     instrumenter: Instrumenter;
@@ -84,8 +86,8 @@ export default class Trace {
         }
 
         const spanList = tracer.getRecorder().getSpanList();
-        const isSampled = get(this.config, 'sampler.isSampled', () => true);
-        const sampled = isSampled(rootSpan);
+        const sampler = get(this.config, 'sampler', { isSampled: () => true });
+        const sampled = sampler.isSampled(rootSpan);
 
         ThundraLogger.debug('<Trace> Checked sampling of transaction', execContext.transactionId, ':', sampled);
 
@@ -93,7 +95,7 @@ export default class Trace {
             const debugEnabled: boolean = ThundraLogger.isDebugEnabled();
             for (const span of spanList) {
                 if (span) {
-                    if (this.config.runSamplerOnEachSpan && !isSampled(span)) {
+                    if (this.config.runSamplerOnEachSpan && !sampler.isSampled(span)) {
                         ThundraLogger.debug(
                             `<Trace> Filtering span with name ${span.getOperationName()} due to custom sampling configuration`);
                         continue;

--- a/src/plugins/config/InvocationConfig.ts
+++ b/src/plugins/config/InvocationConfig.ts
@@ -1,12 +1,28 @@
 import BasePluginConfig from './BasePluginConfig';
+import Sampler from '../../samplers/Sampler';
+import ConfigProvider from '../../config/ConfigProvider';
+import ConfigNames from '../../config/ConfigNames';
+import ErrorAwareSampler from '../../samplers/ErrorAwareSampler';
 
 /**
  * Configures invocation plugin/support
  */
 class InvocationConfig extends BasePluginConfig {
+    sampler: Sampler<any>;
 
     constructor(options: any) {
         super(true);
+
+        options = options ? options : {};
+        this.sampler = options.sampler;
+
+        if (!this.sampler) {
+            const sampleOnError: boolean = ConfigProvider.get<boolean>(
+                ConfigNames.THUNDRA_INVOCATION_SAMPLE_ONERROR, false);
+            if (sampleOnError) {
+                this.sampler = new ErrorAwareSampler();
+            }
+        }
     }
 
 }

--- a/src/samplers/ErrorAwareSampler.ts
+++ b/src/samplers/ErrorAwareSampler.ts
@@ -1,19 +1,28 @@
+import ThundraSpan from '../opentracing/Span';
+import InvocationData from '../plugins/data/invocation/InvocationData';
 import InvocationSupport from '../plugins/support/InvocationSupport';
+
 import Sampler from './Sampler';
 
 /**
  * {@link Sampler} implementation which samples
  * if the invocation is erroneous
  */
-class ErrorAwareSampler implements Sampler<null> {
-
+class ErrorAwareSampler implements Sampler<InvocationData | ThundraSpan> {
     /**
      * @inheritDoc
      */
-    isSampled(): boolean {
-        return InvocationSupport.hasError();
+    isSampled(arg?: InvocationData | ThundraSpan): boolean {
+        if (arg instanceof InvocationData) {
+            const invocationData: InvocationData = arg as InvocationData;
+            return invocationData.erroneous;
+        } else if (arg instanceof ThundraSpan) {
+            const span: ThundraSpan = arg as ThundraSpan;
+            return span.hasErrorTag();
+        } else {
+            return InvocationSupport.hasError();
+        }
     }
-
 }
 
 export default ErrorAwareSampler;

--- a/src/wrappers/WebWrapperUtils.ts
+++ b/src/wrappers/WebWrapperUtils.ts
@@ -51,10 +51,14 @@ export default class WebWrapperUtils {
             await plugin.afterInvocation(context);
         }
 
-        try {
-            await reporter.sendReports(context.reports);
-        } catch (err) {
-            ThundraLogger.error('<WebWrapperUtils> Error occurred while reporting:', err);
+        if (!context.reportingDisabled) {
+            try {
+                await reporter.sendReports(context.reports);
+            } catch (err) {
+                ThundraLogger.error('<WebWrapperUtils> Error occurred while reporting:', err);
+            }
+        } else {
+            ThundraLogger.debug('<WebWrapperUtils> Skipped reporting as reporting is disabled');
         }
     }
 

--- a/src/wrappers/lambda/LambdaHandlerWrapper.ts
+++ b/src/wrappers/lambda/LambdaHandlerWrapper.ts
@@ -12,7 +12,7 @@ import {
     DEBUG_BRIDGE_FILE_NAME,
 } from '../../Constants';
 import Utils from '../../utils/Utils';
-import {readFileSync} from 'fs';
+import { readFileSync } from 'fs';
 import ConfigProvider from '../../config/ConfigProvider';
 import ConfigNames from '../../config/ConfigNames';
 import ExecutionContextManager from '../../context/ExecutionContextManager';
@@ -146,9 +146,9 @@ class LambdaHandlerWrapper {
                         if (ThundraLogger.isDebugEnabled()) {
                             ThundraLogger.debug(
                                 '<LambdaHandlerWrapper> Calling original function with the following arguments:', {
-                                    event: this.originalEvent,
-                                    context: this.wrappedContext,
-                                });
+                                event: this.originalEvent,
+                                context: this.wrappedContext,
+                            });
                         }
                         const result = this.originalFunction.call(
                             this.originalThis,
@@ -174,9 +174,9 @@ class LambdaHandlerWrapper {
                         ThundraLogger.debug(
                             '<LambdaHandlerWrapper> Since Lambda wrapper failed, \
                             calling original function directly with the following arguments:', {
-                                event: this.originalEvent,
-                                context: this.originalContext,
-                            });
+                            event: this.originalEvent,
+                            context: this.originalContext,
+                        });
                     }
                     // There is an error on "before-invocation" phase
                     // So skip Thundra wrapping and call original function directly
@@ -493,7 +493,11 @@ class LambdaHandlerWrapper {
 
         ThundraLogger.debug('<LambdaHandlerWrapper> Sending reports');
 
-        await this.reporter.sendReports(execContext.reports);
+        if (!execContext.reportingDisabled) {
+            await this.reporter.sendReports(execContext.reports);
+        } else {
+            ThundraLogger.debug('<LambdaHandlerWrapper> Skipped reporting as reporting is disabled');
+        }
     }
 
     private async report(error: any, result: any, callback: any) {

--- a/test/plugins/invocation.test.js
+++ b/test/plugins/invocation.test.js
@@ -96,7 +96,7 @@ describe('invocation', () => {
 
             invocation.beforeInvocation(mockExecContext);
             invocation.afterInvocation(mockExecContext);
-            
+
             expect(mockPluginContext.executor.startInvocation).toHaveBeenCalledTimes(1);
             expect(mockPluginContext.executor.startInvocation).toBeCalledWith(mockPluginContext, mockExecContext);
             expect(mockPluginContext.executor.finishInvocation).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Add `thundra_agent_invocation_sample_onerror` Environment Variable
This environment variable is added to overcome an issue caused by a
deprecated variable, `thundra_agent_lambda_sample_timed_out_invocations`.

The main functionality is the same as ErrorAwareSampler, however, gives 
the ability to provide it without code change, via an environment 
variable, to support customers who are using the old variable.

When a sampler and this variable provided at the same time, the sampler
will have the priority and override the environment variable and act
like it's not there.

Within this commit, we also fix an issue in invocation plugin that
were preventing us to receive samples.